### PR TITLE
Remove functionality of looking in CurrentUser hive.

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/OnlineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/OnlineRegistryReader.cs
@@ -22,23 +22,29 @@ namespace SeeShells.ShellParser
         {
             List<RegistryKeyWrapper> retList = new List<RegistryKeyWrapper>();
 
-            //get relevant online registries
-            List<RegistryKey> registryStores = new List<RegistryKey>
-            {
-                Registry.Users,
-                Registry.CurrentUser
-            };
+            //get relevant online registry
+            RegistryKey store = Registry.Users;
 
-
-            foreach (string location in Parser.GetLocations())
+            List<RegistryKey> userStores = new List<RegistryKey>();
+            foreach (string userStoreName in store.GetSubKeyNames())
             {
-                foreach (RegistryKey store in registryStores)
+                userStores.Add(store.OpenSubKey(userStoreName));
+            }
+
+            //iterate over each user's registry
+            foreach (RegistryKey userStore in userStores)
+            {
+                Console.WriteLine("NEW USER SID: " + userStore.Name);
+
+                foreach (string location in Parser.GetLocations())
                 {
-                    foreach (byte[] keyValue in IterateRegistry(store.OpenSubKey(location), location, 0, ""))
+                    foreach (byte[] keyValue in IterateRegistry(userStore.OpenSubKey(location), location, 0, ""))
                     {
                         retList.Add(new RegistryKeyWrapper(keyValue));
                     }
                 }
+                //todo: this is the ideal spot for labeling information by each user if needed.
+                //possible separation of RegistryKeyWrappers by user is also possible above.
             }
 
             return retList;

--- a/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/MockConfigParser.cs
+++ b/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/MockConfigParser.cs
@@ -17,6 +17,8 @@ namespace SeeShellsTests.ShellParser.ShellParserMocks
         public List<string> GetLocations()
         {
             List<String> list = new List<String>();
+            list.Add("Software\\Microsoft\\Windows\\Shell\\");
+            list.Add("Software\\Microsoft\\Windows\\ShellNoRoam\\");
             list.Add("Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell");
             return list;
         }


### PR DESCRIPTION
Sets up future code to be able to divide shellbags by user SID

Updates test for onlineRegistryReader to read both BagsMRU and Bags in all known locations.