### PR TITLE
Add functionality for 2 API calls to WPF

### DIFF
--- a/WPF/SeeShells/SeeShells/IO/Networking/API.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/API.cs
@@ -1,6 +1,10 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using RestSharp;
+using SeeShells.IO.Networking.JSON;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,6 +20,12 @@ namespace SeeShells.IO.Networking
         public const string DEFAULT_WEBSITE_URL = "https://rickleinecker.github.io/SeeShells";
         public const string DEFAULT_WEBSITE_API_ENDPOINT = "apiEndpoint.txt";
 
+        public const string GUID_ENDPOINT = "getGUIDs";
+        private const string DEFAULT_GUID_FILENAME = "SeeShellsGUIDS.json";
+
+        public const string OS_REGISTRY_ENDPOINT = "getOSandRegistryLocations";
+        private const string DEFAULT_OS_REGISTRY_FILENAME = "SeeShellsRegistryLocations.json";
+
 
         /// <summary>
         /// Obtains a <see cref="RestClient"/> which is ready to send requests to the SeeShells API Server.
@@ -24,38 +34,149 @@ namespace SeeShells.IO.Networking
         /// <param name="url">URL of the SeeShells Website that contains the special endpoint.</param>
         /// <param name="endpoint">An endpoint which returns the URL of the API.</param>
         /// <returns>A Task containing a Rest Client ready to make requests to the API.</returns>
-        public static async Task<IRestClient> GetAPIClientAsync(string url = DEFAULT_WEBSITE_URL, string endpoint = DEFAULT_WEBSITE_API_ENDPOINT)
+        /// <exception cref="IOException"> When any networking error occurs during the operation.</exception>
+        public static async Task<IRestClient> GetAPIClient(string url = DEFAULT_WEBSITE_URL, string endpoint = DEFAULT_WEBSITE_API_ENDPOINT)
         {
+            if (url != DEFAULT_WEBSITE_URL)
+                apiClient = null; //meant for unit testing ONLY. If we allow a configurable website later on THIS HAS TO BE REMOVED.
+
             //"cache" the location of the API, so dont do the network call again if we dont have to.
             if (apiClient == null) { 
                 RestClient client = new RestClient(url);
 
-                var request = new RestRequest(endpoint, DataFormat.None);
+                RestRequest request = new RestRequest(endpoint, DataFormat.None);
                 //hit the website to get the URL of the API endpoint
-                var response = await client.ExecuteGetAsync(request);
-                if (response.IsSuccessful)
-                {
-                    try
-                    {
-                        Uri apiURL = new Uri(response.Content);
-
-                        apiClient = new RestClient(apiURL);
-
-                    } catch (UriFormatException ex)
-                    {
-                        logger.Error(ex);
-                    }
+                IRestResponse response = await client.ExecuteGetAsync(request);
+                if (response.ErrorException == null)
+                { 
+                    //convert API url to Uri
+                    Uri apiURL = new Uri(response.Content);
+                    apiClient = new RestClient(apiURL);
                 } 
                 else //without the API endpoint we cant proceed 
                 {
-                    logger.Error("Couldn't retreive API Endpoint:\n" +
-                        response.ErrorMessage + "\n" +
-                        response.Content);
+                    throw new APIException("Couldnt obtain API website", response.ErrorException);
                 }
             }
-
             return apiClient;
         }
 
+        /// <summary>
+        /// Obtains a list of Shellbag GUIDS from the SeeShells API in JSON format and writes to a file
+        /// </summary>
+        /// <param name="outputFilePath">Specific file path in which to save the results. If it doesnt exist it will be created.</param>
+        /// <returns>the filepath in which the data was saved.</returns>
+        /// <exception cref="IOException"> When any networking or file error occurs during the operation.</exception>
+        public static async Task<string> GetGuids(string outputFilePath, IRestClient apiClient = null)
+        {
+            RestRequest guidRequest = new RestRequest(GUID_ENDPOINT, DataFormat.Json);
+            return  await PerformGET(guidRequest, outputFilePath, DEFAULT_GUID_FILENAME, apiClient);
+        }
+
+        /// <summary>
+        /// Obtains a list of Shellbag GUIDS from the SeeShells API in JSON format and writes to a file
+        /// </summary>
+        /// <param name="outputFilePath">Specific file path in which to save the results. If it doesnt exist it will be created.</param>
+        /// <returns>the filepath in which the data was saved.</returns>
+        /// <exception cref="IOException"> When any networking or file error occurs during the operation.</exception>
+        public static async Task<string> GetOSRegistryLocations(string outputFilePath, IRestClient apiClient = null)
+        {
+            RestRequest guidRequest = new RestRequest(OS_REGISTRY_ENDPOINT, DataFormat.Json);
+            return await PerformGET(guidRequest, outputFilePath, DEFAULT_OS_REGISTRY_FILENAME, apiClient);
+        }
+
+
+        /// <summary>
+        /// Performs a GET request on an API Endpoint
+        /// </summary>
+        /// <param name="restRequest">The Request to perform</param>
+        /// <param name="outputFilePath">Specific file path in which to save the results. If it doesnt exist it will be created</param>
+        /// <param name="defaultFileName">filename to be used if outputFilePath isnt defined</param>
+        /// <param name="apiClient">The client to use for the GET operation.</param>
+        /// <returns>An absolute filepath of the written file</returns>
+        /// <exception cref="IOException"> When any networking or file error occurs during the operation.</exception>
+
+        private static async Task<string> PerformGET(RestRequest restRequest, string outputFilePath, string defaultFileName, IRestClient apiClient)
+        {
+            if (apiClient == null)
+            {
+                apiClient = await GetAPIClient();
+            }
+
+            IRestResponse response = apiClient.Get(restRequest);
+            if (response.ErrorException == null)
+            {
+                CheckAPIError(response);
+                return WriteToFile(UnwrapJSONContainer(response), outputFilePath, defaultFileName);
+            }
+            else
+            { 
+                throw new APIException("Networking Error: " + response.ErrorException.Message, response.ErrorException);
+            }
+        }
+
+        /// <summary>
+        /// Writes a file to the filesystem. 
+        /// Resorts to the current directory of the program if no output file is specified. 
+        /// </summary>
+        /// <param name="content">The text contents to be written to teh specified filepath</param>
+        /// <param name="outputFilePath">An absolute filepath of where to write contents to.</param>
+        /// <param name="defaultFileName">filename to be used if outputFilePath isnt defined</param>
+        /// <returns>An absolute filepath of the written file.</returns>
+        /// <exception cref="IOException"></exception>
+        private static string WriteToFile(string content, string outputFilePath, string defaultFileName)
+        {
+            if (string.IsNullOrWhiteSpace(outputFilePath))
+            {
+                //write the contents to the current directory with a default filename
+                string curDirFilepath = Directory.GetCurrentDirectory() + "/" + defaultFileName;
+                File.WriteAllText(curDirFilepath, content);
+
+                return Path.GetFullPath(curDirFilepath);
+                
+            } else
+            {
+                File.WriteAllText(outputFilePath, content);
+                return Path.GetFullPath(outputFilePath);
+            }
+        }
+
+        /// <summary>
+        /// Checks a response for the Error type, throws an <see cref="APIException"/> with the message if true.
+        /// </summary>
+        /// <param name="restResponse">response to check contents for</param>
+        /// <exception cref="APIException">The error message if it was an error.</returns>
+        private static void CheckAPIError(IRestResponse restResponse)
+        {
+            try
+            {
+                APIError json = JsonConvert.DeserializeObject<APIError>(restResponse.Content);
+                throw new APIException("API Error:" + json.Error);
+            }
+            catch (JsonException ex)
+            {
+                logger.Debug(ex);
+                return; //probably not an Error json 
+            }
+        }
+
+        /// <summary>
+        /// unwraps the "json" array that appears in the schema of Guids and OsRegistryLocations.
+        /// Without this step its impossible to determine the inner types for serialization.
+        /// </summary>
+        /// <param name="restResponse">Response from an API endpoint</param>
+        /// <returns>a JSON array of unidentified objects</returns>
+        private static string UnwrapJSONContainer(IRestResponse restResponse)
+        {
+            try
+            {
+               JArray array = JArray.Parse( JObject.Parse(restResponse.Content).GetValue("json").ToString());
+               return array.ToString();
+            } catch (JsonException ex)
+            {
+                throw new APIException("Error parsing API response.", ex);
+            }
+        }
     }
+
 }

--- a/WPF/SeeShells/SeeShells/IO/Networking/API.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/API.cs
@@ -65,6 +65,7 @@ namespace SeeShells.IO.Networking
         /// Obtains a list of Shellbag GUIDS from the SeeShells API in JSON format and writes to a file
         /// </summary>
         /// <param name="outputFilePath">Specific file path in which to save the results. If it doesnt exist it will be created.</param>
+        /// <param name="apiClient">A custom client to use for the GET operation.</param>
         /// <returns>the filepath in which the data was saved.</returns>
         /// <exception cref="IOException"> When any networking or file error occurs during the operation.</exception>
         public static async Task<string> GetGuids(string outputFilePath, IRestClient apiClient = null)
@@ -74,9 +75,10 @@ namespace SeeShells.IO.Networking
         }
 
         /// <summary>
-        /// Obtains a list of Shellbag GUIDS from the SeeShells API in JSON format and writes to a file
+        /// Obtains a list of Operating Systems and their respective Registry file key paths for Shellbag information from the SeeShells API in JSON format and writes to a file.
         /// </summary>
         /// <param name="outputFilePath">Specific file path in which to save the results. If it doesnt exist it will be created.</param>
+        /// <param name="apiClient">A custom client to use for the GET operation.</param>
         /// <returns>the filepath in which the data was saved.</returns>
         /// <exception cref="IOException"> When any networking or file error occurs during the operation.</exception>
         public static async Task<string> GetOSRegistryLocations(string outputFilePath, IRestClient apiClient = null)

--- a/WPF/SeeShells/SeeShells/IO/Networking/API.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/API.cs
@@ -1,0 +1,61 @@
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShells.IO.Networking
+{
+    public class API
+    {
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        
+        private static IRestClient apiClient = null;
+
+        public const string DEFAULT_WEBSITE_URL = "https://rickleinecker.github.io/SeeShells";
+        public const string DEFAULT_WEBSITE_API_ENDPOINT = "apiEndpoint.txt";
+
+
+        /// <summary>
+        /// Obtains a <see cref="RestClient"/> which is ready to send requests to the SeeShells API Server.
+        /// To do so, it must make a request to a special endpoint on the SeeShells website to obtain the API's location. (see SeeShells Design Doc)
+        /// </summary>
+        /// <param name="url">URL of the SeeShells Website that contains the special endpoint.</param>
+        /// <param name="endpoint">An endpoint which returns the URL of the API.</param>
+        /// <returns>A Task containing a Rest Client ready to make requests to the API.</returns>
+        public static async Task<IRestClient> GetAPIClientAsync(string url = DEFAULT_WEBSITE_URL, string endpoint = DEFAULT_WEBSITE_API_ENDPOINT)
+        {
+            //"cache" the location of the API, so dont do the network call again if we dont have to.
+            if (apiClient == null) { 
+                RestClient client = new RestClient(url);
+
+                var request = new RestRequest(endpoint, DataFormat.None);
+                //hit the website to get the URL of the API endpoint
+                var response = await client.ExecuteGetAsync(request);
+                if (response.IsSuccessful)
+                {
+                    try
+                    {
+                        Uri apiURL = new Uri(response.Content);
+
+                        apiClient = new RestClient(apiURL);
+
+                    } catch (UriFormatException ex)
+                    {
+                        logger.Error(ex);
+                    }
+                } 
+                else //without the API endpoint we cant proceed 
+                {
+                    logger.Error("Couldn't retreive API Endpoint:\n" +
+                        response.ErrorMessage + "\n" +
+                        response.Content);
+                }
+            }
+
+            return apiClient;
+        }
+
+    }
+}

--- a/WPF/SeeShells/SeeShells/IO/Networking/APIException.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/APIException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace SeeShells.IO.Networking
+{
+    /// <summary>
+    /// Wrapper Exception for when something goes wrong during API operation
+    /// </summary>
+    public class APIException : IOException
+    {
+        public APIException(string message) : base(message) { }
+        public APIException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/APIError.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/APIError.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShells.IO.Networking.JSON
+{
+    public class APIError
+    {
+        [JsonProperty(propertyName:"success", Required = Required.Always)]
+        public int Success { get; set; }
+        [JsonProperty(propertyName:"error", Required = Required.Always)]
+        public string Error { get; set; }
+
+        public APIError(int success, string error)
+        {
+            Success = success;
+            Error = error; ;
+        }
+
+        public APIError()
+        {
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/APIError.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/APIError.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace SeeShells.IO.Networking.JSON
 {
+    /// <summary>
+    /// C# object representation of an API Call which returned error information instead of it's intended information.
+    /// </summary>
     public class APIError
     {
         [JsonProperty(propertyName:"success", Required = Required.Always)]

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/GUIDPair.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/GUIDPair.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace SeeShells.IO.Networking.JSON
 {
+    /// <summary>
+    /// A GUID seen in Shellbags that has been correlated to a specific title when it appears in a Windows system.
+    /// </summary>
     public class GUIDPair
     {
 

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/GUIDPair.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/GUIDPair.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShells.IO.Networking.JSON
+{
+    public class GUIDPair
+    {
+
+        [JsonProperty(propertyName: "guid", Required = Required.Always)]
+        public string GUID { private get; set; }
+
+        [JsonProperty(propertyName: "name", Required = Required.Always)]
+        public string Name { private get; set; }
+        public GUIDPair(string guid, string name)
+        {
+            GUID = guid;
+            Name = name;
+        }
+
+        public GUIDPair()
+        {
+        }
+
+        public KeyValuePair<string, string> getKnownGUID()
+        {
+            return new KeyValuePair<string, string>(GUID, Name);
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/RegistryLocations.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/RegistryLocations.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 
 namespace SeeShells.IO.Networking.JSON
 {
+    /// <summary>
+    /// Holds a one-to-many resolution of an Operating System's Registry files and registry key path to Shellbags.
+    /// </summary>
     public class RegistryLocations
     {
 

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/RegistryLocations.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/RegistryLocations.cs
@@ -1,0 +1,59 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShells.IO.Networking.JSON
+{
+    public class RegistryLocations
+    {
+
+        /// <summary>
+        /// Operating System 
+        /// </summary>
+        [JsonProperty(propertyName:"os", Required = Required.Always)]
+        public string OperatingSystem { get; set; }
+
+        [JsonProperty(propertyName:"files", Required = Required.Always)]
+        public IList<string> RegistryFilePaths { private get; set; }
+
+
+        public RegistryLocations(string operatingSystem, IList<string> registryFilePaths)
+        {
+            OperatingSystem = operatingSystem;
+            RegistryFilePaths = registryFilePaths;
+        }
+
+        public RegistryLocations()
+        {
+        }
+
+        /// <summary>
+        /// Returns a Dictionary of pairings of Registry files and the registy paths for the shellbags in them.
+        /// Example: ("NTUSER.DAT", ["p\a\t\h\1", "p\a\t\h\2"])
+        /// </summary>
+        /// <returns></returns>
+        public IDictionary<string, IList<string>> GetRegistryFilePaths()
+        {
+            var retDict = new Dictionary<string, IList<string>>();
+            foreach(string path in RegistryFilePaths)
+            {
+                string[] pathSplit = path.Split('\\');
+                string regPath = string.Join("\\", pathSplit.AsEnumerable().Skip(1).ToArray());
+                if (retDict.ContainsKey(pathSplit.First()))
+                {
+                    retDict[pathSplit.First()].Add(regPath);
+                }
+                else
+                {
+                    retDict.Add(pathSplit.First(), new List<string> { regPath });
+                }
+            }
+            return retDict;
+        }
+
+    }
+}

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -52,6 +52,9 @@
     <Reference Include="Registry">
       <HintPath>resources\Registry.dll</HintPath>
     </Reference>
+    <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
@@ -59,6 +62,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
@@ -72,6 +76,7 @@
     </ApplicationDefinition>
     <Compile Include="IO\CsvIO.cs" />
     <Compile Include="IO\CsvParsedShellItem.cs" />
+    <Compile Include="IO\Networking\API.cs" />
     <Compile Include="ShellParser\ShellBagParser.cs" />
     <Compile Include="ShellParser\IRegistryReader.cs" />
     <Compile Include="ShellParser\ShellItems\Block.cs" />

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -43,6 +43,9 @@
       <HintPath>resources\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NFluent">
       <HintPath>resources\NFluent.dll</HintPath>
     </Reference>
@@ -77,6 +80,10 @@
     <Compile Include="IO\CsvIO.cs" />
     <Compile Include="IO\CsvParsedShellItem.cs" />
     <Compile Include="IO\Networking\API.cs" />
+    <Compile Include="IO\Networking\APIException.cs" />
+    <Compile Include="IO\Networking\JSON\APIError.cs" />
+    <Compile Include="IO\Networking\JSON\GUIDPair.cs" />
+    <Compile Include="IO\Networking\JSON\RegistryLocations.cs" />
     <Compile Include="ShellParser\ShellBagParser.cs" />
     <Compile Include="ShellParser\IRegistryReader.cs" />
     <Compile Include="ShellParser\ShellItems\Block.cs" />

--- a/WPF/SeeShells/SeeShells/packages.config
+++ b/WPF/SeeShells/SeeShells/packages.config
@@ -3,4 +3,5 @@
   <package id="NLog" version="4.6.8" targetFramework="net46" />
   <package id="NLog.Config" version="4.6.8" targetFramework="net46" />
   <package id="NLog.Schema" version="4.6.8" targetFramework="net46" />
+  <package id="RestSharp" version="106.10.1" targetFramework="net46" />
 </packages>

--- a/WPF/SeeShells/SeeShells/packages.config
+++ b/WPF/SeeShells/SeeShells/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net46" />
   <package id="NLog" version="4.6.8" targetFramework="net46" />
   <package id="NLog.Config" version="4.6.8" targetFramework="net46" />
   <package id="NLog.Schema" version="4.6.8" targetFramework="net46" />

--- a/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
+++ b/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MockHttpServer;
+using RestSharp;
 using SeeShells.IO.Networking;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -24,10 +26,119 @@ namespace SeeShellsTests.IO.Networking
 
             using (new MockServer(TEST_PORT, API.DEFAULT_WEBSITE_API_ENDPOINT, (req, rsp, prm) => testApiHost))
             {
-                var apiClient = API.GetAPIClientAsync(TEST_URL);
+                var apiClient = API.GetAPIClient(TEST_URL);
                 Assert.IsNotNull(apiClient);
                 Assert.AreEqual(testApiHost, apiClient.Result.BaseUrl.ToString());
             }
         }
+
+        [TestMethod()]
+        public void GetAPIClient_ServerErrorTest()
+        {
+               
+            try
+            {
+                var apiClient = API.GetAPIClient("http://localhost:" + (TEST_PORT+1)).Result;
+                Assert.Fail("Expected Exception"); //expect exception
+
+            }
+            catch (AggregateException ex)
+            {
+                Assert.AreEqual(new APIException("").GetType(), ex.InnerException.GetType());
+            }
+
+        }
+
+
+        [TestMethod()]
+        public void GetGuidsTest()
+        {
+
+            string returnJSON = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleGUIDsResponse.json");
+            string serializedJson = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleGUIDs.json");
+
+
+            using (new MockServer(TEST_PORT, API.GUID_ENDPOINT, (req, rsp, prm) => returnJSON))
+            {
+                var apiClient = new RestClient(TEST_URL);
+
+                var testOutputPath = API.GetGuids("output.json", apiClient).Result;
+
+                Assert.IsNotNull(apiClient);
+                Assert.AreEqual(serializedJson, File.ReadAllText(testOutputPath));
+                File.Delete(testOutputPath);
+            }
+        }
+
+        [TestMethod()]
+        public void GetGuids_ServerErrorTest()
+        {
+            string returnJSON = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleAPIError.json");
+
+            using (new MockServer(TEST_PORT, API.GUID_ENDPOINT, (req, rsp, prm) => returnJSON))
+            {
+                var apiClient = new RestClient(TEST_URL);
+
+                try
+                {
+                    var testOutputPath = API.GetGuids("output.json", apiClient).Result;
+                    Assert.Fail("Expected Exception"); //expect exception
+
+
+                }
+                catch (AggregateException ex)
+                {
+                    Assert.AreEqual(new APIException("").GetType(), ex.InnerException.GetType()); 
+                }
+
+            }
+
+        }
+
+
+
+        [TestMethod()]
+        public void GetOSRegistryLocationsTest()
+        {
+
+            string returnJSON = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleOSRegistryLocationsResponse.json");
+            string serializedJSON = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleOSRegistryLocations.json");
+
+            using (new MockServer(TEST_PORT, API.OS_REGISTRY_ENDPOINT, (req, rsp, prm) => returnJSON))
+            {
+                var apiClient = new RestClient(TEST_URL);
+
+                var testOutputPath = API.GetOSRegistryLocations("output.json", apiClient).Result;
+
+                Assert.IsNotNull(apiClient);
+                Assert.AreEqual(serializedJSON, File.ReadAllText(testOutputPath));
+                File.Delete(testOutputPath);
+            }
+        }
+
+        [TestMethod()]
+        public void GetOSRegistryLocations_ServerErrorTest()
+        {
+            string returnJSON = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleAPIError.json");
+
+            using (new MockServer(TEST_PORT, API.OS_REGISTRY_ENDPOINT, (req, rsp, prm) => returnJSON))
+            {
+                var apiClient = new RestClient(TEST_URL);
+
+                try
+                {
+                    var testOutputPath = API.GetOSRegistryLocations("output.json", apiClient).Result;
+                    Assert.Fail("Expected Exception"); //expect exception
+                }
+                catch (AggregateException ex)
+                {
+                    Assert.AreEqual(new APIException("").GetType(), ex.InnerException.GetType());
+                }
+
+            }
+
+        }
+
+
     }
 }

--- a/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
+++ b/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
@@ -11,13 +11,19 @@ using System.Threading.Tasks;
 
 namespace SeeShellsTests.IO.Networking
 {
+    /// <summary>
+    /// Testing class for various API method calls. 
+    /// All test should use <see cref="MockServer"/> to emulate the server calls without the need of external dependencies. 
+    /// </summary>
     [TestClass()]
     public class APITests
     {
         static readonly int TEST_PORT = 4935; //dont use port 80 because the testing system might already have a webserver
         static readonly string TEST_URL = $"http://localhost:{TEST_PORT}";
 
-
+        /// <summary>
+        /// Test the ability to resolve an API location with <see cref="API.GetAPIClient(string, string)"/>
+        /// </summary>
         [TestMethod()]
         public void GetAPIClientTest()
         {
@@ -32,6 +38,9 @@ namespace SeeShellsTests.IO.Networking
             }
         }
 
+        /// <summary>
+        /// Tests the exception throwing when <see cref="API.GetAPIClient(string, string)"/> fails 
+        /// </summary>
         [TestMethod()]
         public void GetAPIClient_ServerErrorTest()
         {
@@ -49,7 +58,9 @@ namespace SeeShellsTests.IO.Networking
 
         }
 
-
+        /// <summary>
+        /// Checks the functionality of the <see cref="API.GetGuids(string, IRestClient)"/> function
+        /// </summary>
         [TestMethod()]
         public void GetGuidsTest()
         {
@@ -69,7 +80,9 @@ namespace SeeShellsTests.IO.Networking
                 File.Delete(testOutputPath);
             }
         }
-
+        /// <summary>
+        /// Tests the exception throwing when <see cref="API.GetGuids(string, IRestClient)"/> fails 
+        /// </summary>
         [TestMethod()]
         public void GetGuids_ServerErrorTest()
         {
@@ -95,8 +108,9 @@ namespace SeeShellsTests.IO.Networking
 
         }
 
-
-
+        /// <summary>
+        /// Checks the functionality of the <see cref="API.GetOSRegistryLocations(string, IRestClient)"/> function
+        /// </summary>
         [TestMethod()]
         public void GetOSRegistryLocationsTest()
         {
@@ -116,6 +130,9 @@ namespace SeeShellsTests.IO.Networking
             }
         }
 
+        /// <summary>
+        /// Tests the exception throwing when <see cref="API.GetOSRegistryLocations(string, IRestClient)"/> fails.
+        /// </summary>
         [TestMethod()]
         public void GetOSRegistryLocations_ServerErrorTest()
         {

--- a/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
+++ b/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MockHttpServer;
+using SeeShells.IO.Networking;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShellsTests.IO.Networking
+{
+    [TestClass()]
+    public class APITests
+    {
+        static readonly int TEST_PORT = 4935; //dont use port 80 because the testing system might already have a webserver
+        static readonly string TEST_URL = $"http://localhost:{TEST_PORT}";
+
+
+        [TestMethod()]
+        public void GetAPIClientTest()
+        {
+
+            string testApiHost = "http://localhost/api";
+
+            using (new MockServer(TEST_PORT, API.DEFAULT_WEBSITE_API_ENDPOINT, (req, rsp, prm) => testApiHost))
+            {
+                var apiClient = API.GetAPIClientAsync(TEST_URL);
+                Assert.IsNotNull(apiClient);
+                Assert.AreEqual(testApiHost, apiClient.Result.BaseUrl.ToString());
+            }
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShellsTests/IO/Networking/JSONTests.cs
+++ b/WPF/SeeShells/SeeShellsTests/IO/Networking/JSONTests.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using SeeShells.IO.Networking.JSON;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShellsTests.IO.Networking
+{
+    [TestClass()]
+    public class JSONTests
+    {
+
+        [TestMethod]
+        public void APIError_DeserializationTest()
+        {
+            var json = "{\"success\": 0, \"error\": \"Error Occurred\"}";
+            var obj = JsonConvert.DeserializeObject<APIError>(json);
+            Assert.AreEqual(obj.GetType(), new APIError().GetType());
+        }
+
+        [TestMethod]
+        public void GUIDPair_DeserializationTest()
+        {
+            string json = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleGUIDs.json");
+            var obj = JsonConvert.DeserializeObject<IList<GUIDPair>>(json);
+            Assert.AreEqual(obj[0].GetType(), new GUIDPair().GetType());
+        }
+
+
+        [TestMethod]
+        public void RegistryLocations_DeserializationTest()
+        {
+            string json = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleOSRegistryLocations.json");
+            var obj = JsonConvert.DeserializeObject<IList<RegistryLocations>>(json);
+            Assert.AreEqual(obj[0].GetType(), new RegistryLocations().GetType());
+        }
+
+    }
+}

--- a/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
+++ b/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
@@ -49,6 +49,9 @@
     <Reference Include="MockHttpServer, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MockHttpServer.1.4.0.0\lib\net45\MockHttpServer.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
     </Reference>
@@ -73,6 +76,7 @@
   <ItemGroup>
     <Compile Include="IO\CsvIOTests.cs" />
     <Compile Include="IO\Networking\APITests.cs" />
+    <Compile Include="IO\Networking\JSONTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShellParser\ShellBagParserTests.cs" />
     <Compile Include="ShellParser\OnlineRegistryReaderTests.cs" />

--- a/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
+++ b/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
@@ -46,6 +46,12 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="MockHttpServer, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MockHttpServer.1.4.0.0\lib\net45\MockHttpServer.dll</HintPath>
+    </Reference>
+    <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
@@ -53,6 +59,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Transactions" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <Choose>
@@ -65,6 +72,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="IO\CsvIOTests.cs" />
+    <Compile Include="IO\Networking\APITests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShellParser\ShellBagParserTests.cs" />
     <Compile Include="ShellParser\OnlineRegistryReaderTests.cs" />

--- a/WPF/SeeShells/SeeShellsTests/TestResource/sampleAPIError.json
+++ b/WPF/SeeShells/SeeShellsTests/TestResource/sampleAPIError.json
@@ -1,0 +1,1 @@
+{ "success": 0, "error":"Something went wrong" }

--- a/WPF/SeeShells/SeeShellsTests/TestResource/sampleGUIDs.json
+++ b/WPF/SeeShells/SeeShellsTests/TestResource/sampleGUIDs.json
@@ -1,0 +1,10 @@
+[
+  {
+    "guid": "008ca0b1-55b4-4c56-b8a8-4de4b299d3bE",
+    "name": "Account Pictures"
+  },
+  {
+    "guid": "00bcfc5a-ed94-4e48-96a1-3f6217f21990",
+    "name": "RoamingTiles"
+  }
+]

--- a/WPF/SeeShells/SeeShellsTests/TestResource/sampleGUIDsResponse.json
+++ b/WPF/SeeShells/SeeShellsTests/TestResource/sampleGUIDsResponse.json
@@ -1,0 +1,13 @@
+{
+    "success": 1,
+    "json": [
+        {
+            "guid": "008ca0b1-55b4-4c56-b8a8-4de4b299d3bE",
+            "name": "Account Pictures"
+        },
+		{
+            "guid": "00bcfc5a-ed94-4e48-96a1-3f6217f21990",
+            "name": "RoamingTiles"
+        }
+    ]
+}

--- a/WPF/SeeShells/SeeShellsTests/TestResource/sampleOSRegistryLocations.json
+++ b/WPF/SeeShells/SeeShellsTests/TestResource/sampleOSRegistryLocations.json
@@ -1,0 +1,20 @@
+[
+  {
+    "os": "Windows 7",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+    ]
+  },
+  {
+    "os": "Windows 10",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+    ]
+  }
+]

--- a/WPF/SeeShells/SeeShellsTests/TestResource/sampleOSRegistryLocationsResponse.json
+++ b/WPF/SeeShells/SeeShellsTests/TestResource/sampleOSRegistryLocationsResponse.json
@@ -1,0 +1,23 @@
+{
+    "success": 1,
+    "json": [
+		{
+            "os": "Windows 7",
+            "files": [
+                "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+                "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+                "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+                "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+            ]
+        },
+		{
+            "os": "Windows 10",
+            "files": [
+                "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+                "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+                "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+                "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+            ]
+        }
+    ]
+}

--- a/WPF/SeeShells/SeeShellsTests/packages.config
+++ b/WPF/SeeShells/SeeShellsTests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MockHttpServer" version="1.4.0.0" targetFramework="net46" />
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
+  <package id="RestSharp" version="106.10.1" targetFramework="net46" />
 </packages>

--- a/WPF/SeeShells/SeeShellsTests/packages.config
+++ b/WPF/SeeShells/SeeShellsTests/packages.config
@@ -3,5 +3,6 @@
   <package id="MockHttpServer" version="1.4.0.0" targetFramework="net46" />
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net46" />
   <package id="RestSharp" version="106.10.1" targetFramework="net46" />
 </packages>

--- a/docs/apiEndpoint.txt
+++ b/docs/apiEndpoint.txt
@@ -1,0 +1,1 @@
+https://seeshells.herokuapp.com/


### PR DESCRIPTION
- Adds networking dependencies for future api calls
- Adds special endpoint to website for the WPF application
- Adds GUIDs and OsRegistryLocation API Calls and file writing
- Adds json2poco classes
- Adds respective unit tests for all functionality

Resolves #108 & #110