### PR TITLE
Node, NodeCollection and NodeParser Skeleton

### DIFF
--- a/WPF/SeeShells/SeeShells/App.xaml.cs
+++ b/WPF/SeeShells/SeeShells/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using SeeShells.UI;
+using SeeShells.UI.Node;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -13,8 +14,13 @@ namespace SeeShells
     public partial class App : Application
     {
         /// <summary>
-        /// creates an instance of the EventCollection class so that the whole program can access the list of events. 
+        /// Creates an instance of the EventCollection class so that the whole program can access the list of events. 
         /// </summary>
-       public static EventCollection eventCollection = new EventCollection();
+        public static EventCollection eventCollection = new EventCollection();
+
+        /// <summary>
+        /// Creates an instance of the NodeCollection class so that the whole program can access the list of nodes. 
+        /// </summary>
+        public static NodeCollection nodeCollection = new NodeCollection();
     }
 }

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -141,6 +141,9 @@
     <Compile Include="UI\EventCollection.cs" />
     <Compile Include="UI\FilterEventUtils.cs" />
     <Compile Include="UI\IEvent.cs" />
+    <Compile Include="UI\Node\Node.cs" />
+    <Compile Include="UI\Node\NodeCollection.cs" />
+    <Compile Include="UI\Node\NodeParser.cs" />
     <Page Include="UI\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/WPF/SeeShells/SeeShells/UI/Node/Node.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/Node.cs
@@ -3,20 +3,27 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Shapes;
 
 namespace SeeShells.UI.Node
 {
     public class Node
     {
         IEvent aEvent;
-        // TODO:
-        // Add Dot and Block member variables
+        Ellipse dot;
+        Rectangle block;
 
-        // TODO:
-        // Add Dot and Block to constructor
-        public Node(IEvent aEvent)
+        /// <summary>
+        /// The Node is an object that stores event data and has graphical objects to be displayed on a timeline.
+        /// </summary>
+        /// <param name="aEvent">object that stores event/shellbag data</param>
+        /// <param name="dot">object to represent an event on a timeline</param>
+        /// <param name="block">object to display event details on a timeline</param>
+        public Node(IEvent aEvent, Ellipse dot, Rectangle block)
         {
             this.aEvent = aEvent;
+            this.dot = dot;
+            this.block = block;
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/UI/Node/Node.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/Node.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShells.UI.Node
+{
+    public class Node
+    {
+        IEvent aEvent;
+        // TODO:
+        // Add Dot and Block member variables
+
+        // TODO:
+        // Add Dot and Block to constructor
+        public Node(IEvent aEvent)
+        {
+            this.aEvent = aEvent;
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShells.UI.Node
+{
+    public class NodeCollection
+    {
+        /// <summary>
+        /// Creates a global list of Nodes to be accessed through an Instance of the class created in App.xaml.cs
+        /// </summary>
+        public List<Node> nodeList;
+    }
+}

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeParser.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Shapes;
 
 namespace SeeShells.UI.Node
 {
@@ -19,9 +20,12 @@ namespace SeeShells.UI.Node
             
             foreach(IEvent aEvent in eventList)
             {
-                Node node = new Node(aEvent);
-                //TODO:
-                // Node needs a Dot and Box added
+                /// TODO:
+                /// Customize dot and block objects
+                Ellipse dot = new Ellipse();
+                Rectangle block = new Rectangle();
+
+                Node node = new Node(aEvent, dot, block);
 
                 nodeList.Add(node);
             }

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeParser.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeParser.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SeeShells.UI.Node
+{
+    public static class NodeParser
+    {
+        /// <summary>
+        /// This method creates a list of nodes to be used for the timeline
+        /// </summary>
+        /// <param name="eventList">a list of events</param>
+        /// <returns>a list of nodes</returns>
+        public static List<Node> GetNodes(List<IEvent> eventList)
+        {
+            List<Node> nodeList = new List<Node>();
+            
+            foreach(IEvent aEvent in eventList)
+            {
+                Node node = new Node(aEvent);
+                //TODO:
+                // Node needs a Dot and Box added
+
+                nodeList.Add(node);
+            }
+            
+            return nodeList;
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
+++ b/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="UI\FilterEventUtilsTests.cs" />
     <Compile Include="UI\Mocks\MockEvent.cs" />
     <Compile Include="UI\Mocks\MockShellItem.cs" />
+    <Compile Include="UI\NodeCollectionTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/WPF/SeeShells/SeeShellsTests/UI/NodeCollectionTest.cs
+++ b/WPF/SeeShells/SeeShellsTests/UI/NodeCollectionTest.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SeeShells;
+using SeeShells.UI;
+using SeeShells.UI.Node;
+using System;
+using System.Collections.Generic;
+
+namespace SeeShellsTests.UI
+{
+    [TestClass()]
+    public class NodeCollectionTest
+    {
+        [TestMethod()]
+        public void NodeCollectionTests()
+        {
+            List<IEvent> eventList = new List<IEvent>();
+            Event aEvent = new Event("item1", DateTime.Now, null, "Access");
+            eventList.Add(aEvent);
+            App.nodeCollection.nodeList = NodeParser.GetNodes(eventList); //TODO: Will be changed when the Node constructor adds Dot and Block
+            Assert.AreNotEqual(App.nodeCollection.nodeList.Count, 0);
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShellsTests/UI/NodeCollectionTest.cs
+++ b/WPF/SeeShells/SeeShellsTests/UI/NodeCollectionTest.cs
@@ -10,13 +10,16 @@ namespace SeeShellsTests.UI
     [TestClass()]
     public class NodeCollectionTest
     {
+        /// <summary>
+        /// Tests that a list of Nodes is created and saved in the NodeCollection object in App.xml.cs
+        /// </summary>
         [TestMethod()]
         public void NodeCollectionTests()
         {
             List<IEvent> eventList = new List<IEvent>();
             Event aEvent = new Event("item1", DateTime.Now, null, "Access");
             eventList.Add(aEvent);
-            App.nodeCollection.nodeList = NodeParser.GetNodes(eventList); //TODO: Will be changed when the Node constructor adds Dot and Block
+            App.nodeCollection.nodeList = NodeParser.GetNodes(eventList);
             Assert.AreNotEqual(App.nodeCollection.nodeList.Count, 0);
         }
     }


### PR DESCRIPTION
Introduces the following classes:
Node -> Formerly called Pretty Object, containing graphical objects to be displayed on a timeline.
NodeCollection -> Formerly called PrettyObjectCollection, used to store a list of nodes and be globally accessible from the App class
NodeParser -> Used to populate the the list of nodes in the NodeCollection from a list of Events