### PR TITLE
Enables Parse Button

### DIFF
--- a/WPF/SeeShells/SeeShells/App.xaml.cs
+++ b/WPF/SeeShells/SeeShells/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using SeeShells.UI;
+﻿using SeeShells.ShellParser.ShellItems;
+using SeeShells.UI;
 using SeeShells.UI.Node;
 using System;
 using System.Collections.Generic;
@@ -22,5 +23,10 @@ namespace SeeShells
         /// Creates an instance of the NodeCollection class so that the whole program can access the list of nodes. 
         /// </summary>
         public static NodeCollection nodeCollection = new NodeCollection();
+
+        /// <summary>
+        /// Collectin of <see cref="ShellItem"/> which is populated after a parsing operation.
+        /// </summary>
+        public static List<IShellItem> ShellItems { get; set; }
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
@@ -1,10 +1,67 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
-
+using Newtonsoft.Json;
+using SeeShells.IO.Networking.JSON;
+using SeeShells.UI.ViewModels;
+using Microsoft.Win32;
 namespace SeeShells.ShellParser
 {
-    class ConfigParser
+    class ConfigParser : IConfigParser
     {
+        private readonly string OSRegistryFile;
+
+        public string OsVersion {private get; set;}
+
+        public ConfigParser(string guidsFile, string OSRegistryFile)
+        {
+            UpdateKnownGUIDS(guidsFile);
+            OsVersion = getLiveOSVersion();
+            this.OSRegistryFile = OSRegistryFile;
+        }
+
+
+        /// <summary>
+        /// Overrides (or Adds) existing GUID entries into <see cref="KnownGuids.dict"/>
+        /// </summary>
+        /// <param name="guidsFile">A JSON file that contains <see cref="GUIDPair"/></param>
+        private void UpdateKnownGUIDS(string guidsFile)
+        {
+            IList<GUIDPair> guidPairs = JsonConvert.DeserializeObject<IList<GUIDPair>>(File.ReadAllText(guidsFile));
+            foreach(GUIDPair pair in guidPairs)
+            {   
+                KnownGuids.dict[pair.getKnownGUID().Key] = pair.getKnownGUID().Value;
+            }
+
+        }
+
+
+        public List<string> GetRegistryLocations()
+        {
+            List<string> locations = new List<string>();
+
+            IList<RegistryLocations> registryLocations = JsonConvert.DeserializeObject<IList<RegistryLocations>>(File.ReadAllText(OSRegistryFile));
+            foreach (RegistryLocations regLocation in registryLocations)
+            {
+                if (OsVersion.Contains(regLocation.OperatingSystem))
+                {
+                    foreach (IList<string> registryPaths in regLocation.GetRegistryFilePaths().Values)
+                    {
+                        locations.AddRange(registryPaths);
+                    }
+                    return locations;
+                }
+            }
+
+            return locations;
+        }
+        
+        private string getLiveOSVersion()
+        {
+            RegistryKey registryKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("Software\\Microsoft\\Windows NT\\CurrentVersion");
+            return (string)registryKey.GetValue("productName");   
+        }
+
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/IConfigParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/IConfigParser.cs
@@ -6,9 +6,7 @@ namespace SeeShells.ShellParser
 {
     public interface IConfigParser
     {
-        void GetConfig();
-        void ParseConfig();
-        List<String> GetLocations();
+        List<string> GetRegistryLocations();
 
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/OfflineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/OfflineRegistryReader.cs
@@ -24,7 +24,7 @@ namespace SeeShells.ShellParser
         {
             List<RegistryKeyWrapper> retList = new List<RegistryKeyWrapper>();
 
-            foreach (string location in Parser.GetLocations())
+            foreach (string location in Parser.GetRegistryLocations())
             {
                 var hive = new RegistryHiveOnDemand(RegistryFilePath);
 

--- a/WPF/SeeShells/SeeShells/ShellParser/OnlineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/OnlineRegistryReader.cs
@@ -36,7 +36,7 @@ namespace SeeShells.ShellParser
             {
                 Console.WriteLine("NEW USER SID: " + userStore.Name);
 
-                foreach (string location in Parser.GetLocations())
+                foreach (string location in Parser.GetRegistryLocations())
                 {
                     foreach (byte[] keyValue in IterateRegistry(userStore.OpenSubKey(location), location, 0, ""))
                     {

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellBagParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellBagParser.cs
@@ -7,19 +7,14 @@ namespace SeeShells.ShellParser
     /// <summary>
     /// This class is used to obtain and identify ShellBag items. 
     /// </summary>
-    public class ShellBagParser
+    public static class ShellBagParser
     {
-        IRegistryReader registryReader;
-        public ShellBagParser(IRegistryReader registryReader)
-        {
-            this.registryReader = registryReader;
-        }
 
         /// <summary>
         /// Identifies and gathers ShellBag items from raw binary registry data.
         /// </summary>
         /// <returns>a list of different variety ShellBag items</returns>
-        public List<IShellItem> GetShellItems()
+        public static List<IShellItem> GetShellItems(IRegistryReader registryReader)
         {
             List<IShellItem> shellItems = new List<IShellItem>();
             foreach (RegistryKeyWrapper keyWrapper in registryReader.GetRegistryKeys())

--- a/WPF/SeeShells/SeeShellsTests/ShellParser/ShellBagParserTests.cs
+++ b/WPF/SeeShells/SeeShellsTests/ShellParser/ShellBagParserTests.cs
@@ -18,8 +18,7 @@ namespace SeeShellsTests.ShellParser
         [TestCategory("OnlineTest")]
         public void GetShellItemsOnlineTest()
         {
-            ShellBagParser shellBagParser = new ShellBagParser(new OnlineRegistryReader(new MockConfigParser()));
-            List<IShellItem> shellItems = shellBagParser.GetShellItems();
+            List<IShellItem> shellItems = ShellBagParser.GetShellItems(new OnlineRegistryReader(new MockConfigParser()));
 
             Assert.AreNotEqual(shellItems.Count, 0);
         }
@@ -31,8 +30,7 @@ namespace SeeShellsTests.ShellParser
         public void GetShellItemsOfflineTest()
         {
             String registryFilePath = Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\NTUSER.DAT";
-            ShellBagParser shellBagParser = new ShellBagParser(new OfflineRegistryReader(new OfflineMockConfigParser(), registryFilePath));
-            List<IShellItem> shellItems = shellBagParser.GetShellItems();
+            List<IShellItem> shellItems = ShellBagParser.GetShellItems(new OfflineRegistryReader(new OfflineMockConfigParser(), registryFilePath));
 
             Assert.AreNotEqual(shellItems.Count, 0);
         }

--- a/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/MockConfigParser.cs
+++ b/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/MockConfigParser.cs
@@ -9,23 +9,14 @@ namespace SeeShellsTests.ShellParser.ShellParserMocks
 {
     class MockConfigParser : IConfigParser
     {
-        public void GetConfig()
-        {
-            throw new NotImplementedException();
-        }
 
-        public List<string> GetLocations()
+        public List<string> GetRegistryLocations()
         {
             List<String> list = new List<String>();
             list.Add("Software\\Microsoft\\Windows\\Shell\\");
             list.Add("Software\\Microsoft\\Windows\\ShellNoRoam\\");
             list.Add("Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell");
             return list;
-        }
-
-        public void ParseConfig()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/OfflineMockConfigParser.cs
+++ b/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/OfflineMockConfigParser.cs
@@ -9,21 +9,12 @@ namespace SeeShellsTests.ShellParser.ShellParserMocks
 {
     class OfflineMockConfigParser : IConfigParser
     {
-        public void GetConfig()
-        {
-            throw new NotImplementedException();
-        }
 
-        public List<string> GetLocations()
+        public List<string> GetRegistryLocations()
         {
             List<String> list = new List<String>();
             list.Add(@"Software\Microsoft\Windows\Shell");
             return list;
-        }
-
-        public void ParseConfig()
-        {
-            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
- Makes ShellBagParser a static class and method
- Creates a global ShellItem list for the purposes of exporting
- Not fully functional until Timeline & EventParser can be applied
- Implements ConfigParser and Refactors IConfigParser
- Creates Debug MessageBox for output of parse button

Questionably resolves #129 

**Not to be merged until #134 is merged**