### PR TITLE
#155 fixes various filtering errors

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/EventFilters/AnyStringFilter.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventFilters/AnyStringFilter.cs
@@ -107,7 +107,6 @@ namespace SeeShells.UI.EventFilters
                     //if we found a match add result
                     if (!foundMatch)
                     {
-                        //nodes.Remove(node);
                         node.dot.Visibility = System.Windows.Visibility.Collapsed;
 
                     }

--- a/WPF/SeeShells/SeeShells/UI/EventFilters/DateRangeFilter.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventFilters/DateRangeFilter.cs
@@ -34,7 +34,8 @@ namespace SeeShells.UI.EventFilters {
                 //if the event falls outside of our two DateTime bounds
                 if (DateTime.Compare(startDate, nEvent.EventTime) > 0 || DateTime.Compare(nEvent.EventTime, endDate) > 0)
                 {
-                    events.Remove(node);   
+                    node.dot.Visibility = System.Windows.Visibility.Collapsed;
+
                 }
             }
 

--- a/WPF/SeeShells/SeeShells/UI/EventFilters/EventNameFilter.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventFilters/EventNameFilter.cs
@@ -26,6 +26,9 @@ namespace SeeShells.UI.EventFilters
         }
         public void Apply(ref List<Node.Node> nodes)
         {
+            if (names.Length == 1 && names[0].Equals(string.Empty))
+                return;
+
             for (int i = nodes.Count-1; i >= 0; i--) //iterate backwards because iterating forwards would be an issue with a list of changing size.
             {
                 Node.Node node = nodes[i];
@@ -43,7 +46,6 @@ namespace SeeShells.UI.EventFilters
 
                 if (!acceptableName)
                 {
-                    //nodes.Remove(node);
                     node.dot.Visibility = System.Windows.Visibility.Collapsed;
                 }
             }

--- a/WPF/SeeShells/SeeShells/UI/EventFilters/EventParentFilter.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventFilters/EventParentFilter.cs
@@ -45,7 +45,6 @@ namespace SeeShells.UI.EventFilters
 
                 if (!acceptableParent)
                 {
-                    //nodes.Remove(node);
                     node.dot.Visibility = System.Windows.Visibility.Collapsed;
                 }
             }

--- a/WPF/SeeShells/SeeShells/UI/EventFilters/EventTypeFilter.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventFilters/EventTypeFilter.cs
@@ -23,6 +23,11 @@ namespace SeeShells.UI.EventFilters {
         }
         public void Apply(ref List<Node.Node> nodes)
         {
+            if (eventTypes.Length == 0)
+            {
+                return; //dont apply filter if no filters
+            }
+
             for (int i = nodes.Count-1; i >= 0; i--)//iterate backwards because iterating forwards would be an issue with a list of changing size.
             {
                 Node.Node node = nodes[i];
@@ -40,7 +45,6 @@ namespace SeeShells.UI.EventFilters {
 
                 if (!acceptableType)
                 {
-                    nodes.Remove(node);
                     node.dot.Visibility = System.Windows.Visibility.Collapsed;
                 }
             }

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
@@ -41,6 +41,11 @@ namespace SeeShells.UI.Node
 
             if (didRemove)
             {
+                //restore visibility of previously filtered events
+                foreach (var node in nodeList)
+                {
+                    node.dot.Visibility = System.Windows.Visibility.Visible;
+                }
                 //reapply all remaining filters
                 foreach (INodeFilter filter in filterList.Values)
                 {

--- a/WPF/SeeShells/SeeShellsTests/UI/NodeFilterTests.cs
+++ b/WPF/SeeShells/SeeShellsTests/UI/NodeFilterTests.cs
@@ -46,6 +46,7 @@ namespace SeeShellsTests.UI.Tests
                 new MockNode(eventList.ElementAt(1)),
                 new MockNode(eventList.ElementAt(2))
             };
+            var startListSize = testList.Count;
 
             List<Node> testListCopy; //reset this list each test because we are removing references from this list.
 
@@ -58,25 +59,30 @@ namespace SeeShellsTests.UI.Tests
             testListCopy = new List<Node>(testList);
             new DateRangeFilter(startLimit, endLimit).Apply(ref testListCopy);
             Assert.AreEqual(1, countVisible(testListCopy));
-            
+            Assert.AreEqual(startListSize, testListCopy.Count);
+
 
             //test the startdate limit
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new DateRangeFilter(startLimit, null).Apply(ref testListCopy);
             Assert.AreEqual(2, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //test enddate limit
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new DateRangeFilter(null, endLimit).Apply(ref testListCopy);
             Assert.AreEqual(2, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //test full range (aka pointless filter)
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new DateRangeFilter(null, null).Apply(ref testListCopy);
             Assert.AreEqual(3, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
+
         }
 
         [TestMethod()]
@@ -95,6 +101,7 @@ namespace SeeShellsTests.UI.Tests
                 new MockNode(eventList.ElementAt(1)),
                 new MockNode(eventList.ElementAt(2))
             };
+            var startListSize = testList.Count;
 
             List<Node> testListCopy; //reset this list each test because we are removing references from this list.
 
@@ -104,18 +111,22 @@ namespace SeeShellsTests.UI.Tests
             testListCopy = new List<Node>(testList);
             new EventTypeFilter("Access").Apply(ref testListCopy);
             Assert.AreEqual(1, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //test multifilter
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new EventTypeFilter("Access", "Create").Apply(ref testListCopy);
             Assert.AreEqual(2, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //test no filter
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new EventTypeFilter("").Apply(ref testListCopy);
             Assert.AreEqual(0, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
+
         }
 
         [TestMethod()]
@@ -136,6 +147,7 @@ namespace SeeShellsTests.UI.Tests
                 new MockNode(eventList.ElementAt(1)),
                 new MockNode(eventList.ElementAt(2))
             };
+            var startListSize = testList.Count;
 
             List<Node> testListCopy; //reset this list each test because we are removing references from this list.
 
@@ -145,18 +157,22 @@ namespace SeeShellsTests.UI.Tests
             testListCopy = new List<Node>(testList);
             new EventParentFilter(parent1).Apply(ref testListCopy);
             Assert.AreEqual(2, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //check diff parent
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new EventParentFilter(parent2).Apply(ref testListCopy);
             Assert.AreEqual(1, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //check unknown parent
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new EventParentFilter(new MockShellItem()).Apply(ref testListCopy);
             Assert.AreEqual(0, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
+
         }
 
         [TestMethod()]
@@ -175,6 +191,8 @@ namespace SeeShellsTests.UI.Tests
                 new MockNode(eventList.ElementAt(1)),
                 new MockNode(eventList.ElementAt(2))
             };
+            var startListSize = testList.Count;
+
 
             List<Node> testListCopy; //reset this list each test because we are removing references from this list.
 
@@ -184,18 +202,21 @@ namespace SeeShellsTests.UI.Tests
             testListCopy = new List<Node>(testList);
             new EventNameFilter("item1").Apply(ref testListCopy);
             Assert.AreEqual(2, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //check no name
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new EventNameFilter("item2").Apply(ref testListCopy);
             Assert.AreEqual(0, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //check multi names
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new EventNameFilter("item1", "item3").Apply(ref testListCopy);
             Assert.AreEqual(3, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
         }
 
@@ -218,6 +239,7 @@ namespace SeeShellsTests.UI.Tests
                 new MockNode(eventList.ElementAt(1)),
                 new MockNode(eventList.ElementAt(2))
             };
+            var startListSize = testList.Count;
 
             List<Node> testListCopy; //reset this list each test because we are removing references from this list.
 
@@ -228,30 +250,35 @@ namespace SeeShellsTests.UI.Tests
             testListCopy = new List<Node>(testList);
             new AnyStringFilter("item1",false).Apply(ref testListCopy);
             Assert.AreEqual(2, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //check for partial match to all items
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new AnyStringFilter("item", false).Apply(ref testListCopy);
             Assert.AreEqual(3, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //check for regex expression ( .* = match all)
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new AnyStringFilter(".*", true).Apply(ref testListCopy);
             Assert.AreEqual(3, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //check for external attribute matching outside of IEvent (test type byte value)
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new AnyStringFilter("02", false).Apply(ref testListCopy);
             Assert.AreEqual(3, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //test for no results
             resetVisibility(testList);
             testListCopy = new List<Node>(testList);
             new AnyStringFilter("SeeShell", false).Apply(ref testListCopy);
             Assert.AreEqual(0, countVisible(testListCopy));
+            Assert.AreEqual(startListSize, testListCopy.Count);
 
             //test for regex timeout 
             //TODO Find hard enough regex that actually takes time no matter the PC?


### PR DESCRIPTION
- fixed error where datetime and event type filters would destroy nodes instead of hiding
- modified unit tests to check for consistent number of nodes during filtering
- Added "blank" filter handling for event name and event type
- added functionality to restore nodes previously hidden when removing filters

Resolves #155 