### PR TITLE
Add script API endpoint adds a script to the database

### DIFF
--- a/api/databaseconnection.js
+++ b/api/databaseconnection.js
@@ -194,6 +194,38 @@ function GUIDDoesNotExist(guid) {
     });
 }
 
+function addScript(identifier, script) {
+    return new Promise(function (resolve, reject) {
+        pool.query('INSERT INTO scripts(typeidentifier, script) values($1, $2);', [identifier, script], (err, res) => {
+            if (err) {
+                reject(err);
+            }
+
+            resolve({ "message": "Success" });
+        });
+    });
+}
+
+function scriptForIdentifierDoesNotExist(identifier) {
+    return new Promise(function (resolve, reject) {
+        pool.query('SELECT id FROM scripts WHERE typeidentifier=$1;', [identifier], (err, res) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            if (res.rowCount > 0) {
+                reject({
+                    result: res.rowCount
+                });
+                return;
+            }
+
+            resolve({ result: "No script exists for this shell item identifier." });
+        });
+    });
+}
+
 module.exports = {
     pool,
     session,
@@ -207,6 +239,8 @@ module.exports = {
     getRegistryLocations,
     getGUIDs,
     addGUID,
-    GUIDDoesNotExist
+    GUIDDoesNotExist,
+    addScript,
+    scriptForIdentifierDoesNotExist
 }
 

--- a/api/databaseconnection.js
+++ b/api/databaseconnection.js
@@ -194,9 +194,9 @@ function GUIDDoesNotExist(guid) {
     });
 }
 
-function addScript(identifier, script) {
+function addScript(identifier, encodedscript) {
     return new Promise(function (resolve, reject) {
-        pool.query('INSERT INTO scripts(typeidentifier, script) values($1, $2);', [identifier, script], (err, res) => {
+        pool.query('INSERT INTO scripts(typeidentifier, script) values($1, $2);', [identifier, encodedscript], (err, res) => {
             if (err) {
                 reject(err);
             }
@@ -226,6 +226,18 @@ function scriptForIdentifierDoesNotExist(identifier) {
     });
 }
 
+// this will return the scripts, but they will be base64 encoded
+// the website will need to decode it
+function getScripts(callback) {
+    pool.query('SELECT typeidentifier, script FROM scripts;', (err, res) => {
+        if (err) {
+            callback({});
+        }
+
+        callback(res.rows);
+    });
+}
+
 module.exports = {
     pool,
     session,
@@ -241,6 +253,7 @@ module.exports = {
     addGUID,
     GUIDDoesNotExist,
     addScript,
-    scriptForIdentifierDoesNotExist
+    scriptForIdentifierDoesNotExist,
+    getScripts
 }
 

--- a/api/index.js
+++ b/api/index.js
@@ -219,6 +219,32 @@ app.get('/getRegistryLocations', function (req, res) {
     );
 });
 
+app.post('/addScript', function (req, res) {
+    var identifier = String(req.body.identifier);
+    var script = String(req.body.script);
+
+    let promise = database.scriptForIdentifierDoesNotExist(identifier);
+    promise.then(
+        function (value) {
+            let addPromise = database.addScript(identifier, script);
+            addPromise.then(
+                function (value) {
+                    res.send({ "success": 1 });
+                },
+                function (err) {
+                    res.send({ "success": 0, "error": "Failed to add new script." });
+                }
+            );
+        },
+        function (err) { 
+            if(err.result >= 1)
+                res.send({ "success": 0, "error": "Script exists in the database already for this identifier." });
+            else
+                res.send({ "success": 0, "error": err.message });
+        }
+    );
+});
+
 app.get('/logout', function (req, res) {
     req.session.destroy(function (err) {
         if (err) {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -183,6 +183,22 @@
         }
       }
     },
+    "express-validator": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.4.0.tgz",
+      "integrity": "sha512-Fs+x0yDOSiUV+o5jIRloMyBxqpSzJiMM8KQW1IRVv2l49F6ATU0F9uPa+3K6vXNlLlhUjauv2FCGLFPMaNr24w==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "validator": "^12.1.0"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
+          "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+        }
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -236,6 +252,11 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -431,6 +452,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sanitize/-/sanitize-2.1.0.tgz",
+      "integrity": "sha512-HLDVriFJnrm6ElDe2E8alAKDMZGMtM8CdKhvunp9592j8hNwZmmsmhk/t6WZbWonKJsHK0OoxH5S1Yoie4sSpw==",
+      "requires": {
+        "lodash": "^4.17.0",
+        "validator": "^3.33.0"
+      }
+    },
     "semver": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
@@ -528,6 +558,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "validator": {
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
+      "integrity": "sha1-lkZLmS1BloM9l6GUv0Cxn/VLrgU="
     },
     "vary": {
       "version": "1.1.2",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -35,13 +35,11 @@
         "type-is": "~1.6.17"
       }
     },
-
     "buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
-
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -300,7 +298,6 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
-
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -389,7 +386,6 @@
         "xtend": "^4.0.0"
       }
     },
-
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,8 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
-    "pg": "^7.17.1"
+    "express-validator": "^6.4.0",
+    "pg": "^7.17.1",
+    "sanitize": "^2.1.0"
   }
 }


### PR DESCRIPTION
Resolves #81 
Edited:
Resolves #82 

The add scripts endpoint will only accept base 64 encoded strings. When a user inputs a script on the website, the script will need to be encoded before being sent.

The get scripts endpoint will return these encoded strings. When the website receives these, it will need to decode them before displaying them to the user.