### PR TITLE
NLog Fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ npm-debug.log
 .vs
 /*.env
 .idea
+/api/node_modules
+/api/.env

--- a/WPF/SeeShells/.gitignore
+++ b/WPF/SeeShells/.gitignore
@@ -277,6 +277,7 @@ FakesAssemblies/
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
 node_modules/
+api/node_modules
 
 # Visual Studio 6 build log
 *.plg

--- a/WPF/SeeShells/SeeShells/IO/Networking/API.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/API.cs
@@ -8,12 +8,13 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NLog;
 
 namespace SeeShells.IO.Networking
 {
     public class API
     {
-        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
         
         private static IRestClient apiClient = null;
 

--- a/WPF/SeeShells/SeeShells/NLog.config
+++ b/WPF/SeeShells/SeeShells/NLog.config
@@ -6,8 +6,16 @@
       throwExceptions="false"
       internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log">
 
+
   <targets>
-    <target name="console" xsi:type="Console" />
+    <target name="logconsole" xsi:type="Console" /> 
+    <target name="file" xsi:type="File" fileName="${basedir}/log.txt" />
   </targets>
+
+  <rules>
+    <logger name="*" minlevel="Trace" writeTo="logconsole"/>
+    <logger name="*" minlevel="Trace" writeTo="file" />
+  </rules>
+
 
 </nlog>

--- a/WPF/SeeShells/SeeShells/UI/MainWindow.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/MainWindow.xaml.cs
@@ -10,14 +10,17 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using NLog;
 
 namespace SeeShells
 {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
+    /// 
     public partial class MainWindow : Window
     {
+
         public MainWindow()
         {
             InitializeComponent();


### PR DESCRIPTION
Resolves #168 

If too much information is being printed, you can modify minlevel in the logger rules.