### PR TITLE
Order events by ascending eventTimes during list creation

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/EventParser.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventParser.cs
@@ -32,7 +32,7 @@ namespace SeeShells.UI
                     }
                 }
             }
-            return eventList;
+            return eventList.OrderBy(o => o.EventTime).ToList();
         }
     }
 }

--- a/WPF/SeeShells/SeeShellsTests/UI/EventParserTest.cs
+++ b/WPF/SeeShells/SeeShellsTests/UI/EventParserTest.cs
@@ -13,10 +13,10 @@ using SeeShells.IO;
 
 namespace SeeShellsTests.UI
 {
-    [TestClass]
-    class EventParserTest
+    [TestClass()]
+    public class EventParserTest
     {
-        [TestMethod]
+        [TestMethod()]
         public void EventListOutput()
         {
             List<IShellItem> shellItems = new List<IShellItem>();


### PR DESCRIPTION
- fixes unit test for EventParser to run with MSTest

Resolves #170 