### PR TITLE
Embedded Scripting

### DIFF
--- a/WPF/SeeShells/SeeShells/App.xaml.cs
+++ b/WPF/SeeShells/SeeShells/App.xaml.cs
@@ -29,10 +29,5 @@ namespace SeeShells
         /// Collectin of <see cref="ShellItem"/> which is populated after a parsing operation.
         /// </summary>
         public static List<IShellItem> ShellItems { get; set; }
-
-        /// <summary>
-        /// An object to hold and provide the scripts needed for the embedded scripting portion of the program.
-        /// </summary>
-        public static ScriptHandler Scripts = new ScriptHandler();
     }
 }

--- a/WPF/SeeShells/SeeShells/App.xaml.cs
+++ b/WPF/SeeShells/SeeShells/App.xaml.cs
@@ -1,5 +1,4 @@
-﻿using SeeShells.ShellParser.Scripting;
-using SeeShells.ShellParser.ShellItems;
+﻿using SeeShells.ShellParser.ShellItems;
 using SeeShells.UI;
 using SeeShells.UI.Node;
 using System;

--- a/WPF/SeeShells/SeeShells/App.xaml.cs
+++ b/WPF/SeeShells/SeeShells/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using SeeShells.ShellParser.ShellItems;
+﻿using SeeShells.ShellParser.Scripting;
+using SeeShells.ShellParser.ShellItems;
 using SeeShells.UI;
 using SeeShells.UI.Node;
 using System;
@@ -28,5 +29,10 @@ namespace SeeShells
         /// Collectin of <see cref="ShellItem"/> which is populated after a parsing operation.
         /// </summary>
         public static List<IShellItem> ShellItems { get; set; }
+
+        /// <summary>
+        /// An object to hold and provide the scripts needed for the embedded scripting portion of the program.
+        /// </summary>
+        public static ScriptHandler Scripts = new ScriptHandler();
     }
 }

--- a/WPF/SeeShells/SeeShells/IO/Networking/API.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/API.cs
@@ -27,6 +27,9 @@ namespace SeeShells.IO.Networking
         public const string OS_REGISTRY_ENDPOINT = "getOSandRegistryLocations";
         private const string DEFAULT_OS_REGISTRY_FILENAME = "SeeShellsRegistryLocations.json";
 
+        public const string SCRIPTS_ENDPOINT = "getScripts";
+        private const string DEFAULT_SCRIPTS_FILENAME = "SeeShellsScripts.json";
+
 
         /// <summary>
         /// Obtains a <see cref="RestClient"/> which is ready to send requests to the SeeShells API Server.
@@ -86,6 +89,19 @@ namespace SeeShells.IO.Networking
         {
             RestRequest guidRequest = new RestRequest(OS_REGISTRY_ENDPOINT, DataFormat.Json);
             return await PerformGET<IList<RegistryLocations>>(guidRequest, outputFilePath, DEFAULT_OS_REGISTRY_FILENAME, apiClient);
+        }
+
+        /// <summary>
+        /// Obtains a list of Shellbag scripts from the SeeShells API in JSON format and writes to a file
+        /// </summary>
+        /// <param name="outputFilePath">Specific file path in which to save the results. If it doesnt exist it will be created.</param>
+        /// <param name="apiClient">A custom client to use for the GET operation.</param>
+        /// <returns>the filepath in which the data was saved.</returns>
+        /// <exception cref="IOException"> When any networking or file error occurs during the operation.</exception>
+        public static async Task<string> GetScripts(string outputFilePath, IRestClient apiClient = null)
+        {
+            RestRequest scriptsRequest = new RestRequest(SCRIPTS_ENDPOINT, DataFormat.Json);
+            return await PerformGET<IList<ScriptPair>>(scriptsRequest, outputFilePath, DEFAULT_SCRIPTS_FILENAME, apiClient);
         }
 
 

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/ScriptPair.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/ScriptPair.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace SeeShells.IO.Networking.JSON
+{
+    public class ScriptPair
+    {
+
+        [JsonProperty(propertyName: "identifier", Required = Required.Always)]
+        public int Identifier { private get; set; }
+
+        [JsonProperty(propertyName: "script", Required = Required.Always)]
+        public string Script { private get; set; }
+        public ScriptPair(int identifier, string script)
+        {
+            Identifier = identifier;
+            Script = script;
+        }
+
+        public ScriptPair() { }
+
+        public KeyValuePair<int, string> getScript()
+        {
+            return new KeyValuePair<int, string>(Identifier, Script);
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/ScriptPair.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/ScriptPair.cs
@@ -10,8 +10,6 @@ namespace SeeShells.IO.Networking.JSON
     public class ScriptPair
     {
 
-        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
-
         public int typeidentifier { get; set; }
 
         private string decodedScript;
@@ -25,15 +23,24 @@ namespace SeeShells.IO.Networking.JSON
 
         public ScriptPair() { }
 
-        public KeyValuePair<int, string> getScript()
-        {
-            return new KeyValuePair<int, string>(typeidentifier, decodedScript);
-        }
-
         private static string Base64Decode(string base64EncodedData)
         {
             var base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
             return Encoding.UTF8.GetString(base64EncodedBytes);
+        }
+    }
+
+    public class DecodedScriptPair
+    {
+
+        public int typeidentifier { get; set; }
+        public string script { get; set; }
+
+        public DecodedScriptPair() { }
+
+        public KeyValuePair<int, string> getScript()
+        {
+            return new KeyValuePair<int, string>(typeidentifier, script);
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/ScriptPair.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/ScriptPair.cs
@@ -10,22 +10,30 @@ namespace SeeShells.IO.Networking.JSON
     public class ScriptPair
     {
 
-        [JsonProperty(propertyName: "identifier", Required = Required.Always)]
-        public int Identifier { private get; set; }
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-        [JsonProperty(propertyName: "script", Required = Required.Always)]
-        public string Script { private get; set; }
-        public ScriptPair(int identifier, string script)
-        {
-            Identifier = identifier;
-            Script = script;
+        public int typeidentifier { get; set; }
+
+        private string decodedScript;
+        public string script { 
+            get { return decodedScript; }
+            set
+            {
+                decodedScript = Base64Decode(value);
+            }
         }
 
         public ScriptPair() { }
 
         public KeyValuePair<int, string> getScript()
         {
-            return new KeyValuePair<int, string>(Identifier, Script);
+            return new KeyValuePair<int, string>(typeidentifier, decodedScript);
+        }
+
+        private static string Base64Decode(string base64EncodedData)
+        {
+            var base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
+            return Encoding.UTF8.GetString(base64EncodedBytes);
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -109,6 +109,8 @@
     <Compile Include="IO\Networking\JSON\APIError.cs" />
     <Compile Include="IO\Networking\JSON\GUIDPair.cs" />
     <Compile Include="IO\Networking\JSON\RegistryLocations.cs" />
+    <Compile Include="ShellParser\Scripting\LuaShellItem.cs" />
+    <Compile Include="ShellParser\Scripting\ScriptHandler.cs" />
     <Compile Include="ShellParser\ShellBagParser.cs" />
     <Compile Include="ShellParser\IRegistryReader.cs" />
     <Compile Include="ShellParser\ShellItems\Block.cs" />

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -109,6 +109,7 @@
     <Compile Include="IO\Networking\JSON\APIError.cs" />
     <Compile Include="IO\Networking\JSON\GUIDPair.cs" />
     <Compile Include="IO\Networking\JSON\RegistryLocations.cs" />
+    <Compile Include="IO\Networking\JSON\ScriptPair.cs" />
     <Compile Include="ShellParser\Scripting\LuaShellItem.cs" />
     <Compile Include="ShellParser\Scripting\ScriptHandler.cs" />
     <Compile Include="ShellParser\ShellBagParser.cs" />

--- a/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
@@ -54,8 +54,8 @@ namespace SeeShells.ShellParser
 
         private void UpdateScripts(string file)
         {
-            IList<ScriptPair> scriptPairs = JsonConvert.DeserializeObject<IList<ScriptPair>>(File.ReadAllText(file));
-            foreach(ScriptPair pair in scriptPairs)
+            IList<DecodedScriptPair> scriptPairs = JsonConvert.DeserializeObject<IList<DecodedScriptPair>>(File.ReadAllText(file));
+            foreach(DecodedScriptPair pair in scriptPairs)
             {
                 ScriptHandler.scripts[pair.getScript().Key] = pair.getScript().Value;   
             }

--- a/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
@@ -6,6 +6,8 @@ using Newtonsoft.Json;
 using SeeShells.IO.Networking.JSON;
 using SeeShells.UI.ViewModels;
 using Microsoft.Win32;
+using SeeShells.ShellParser.Scripting;
+
 namespace SeeShells.ShellParser
 {
     class ConfigParser : IConfigParser
@@ -20,6 +22,20 @@ namespace SeeShells.ShellParser
             OsVersion = getLiveOSVersion();
             this.OSRegistryFile = OSRegistryFile;
         }
+        /// <summary>
+        /// Scripts are optional, so use this constructor when there is a selected scripts file.
+        /// </summary>
+        /// <param name="guidsFile"></param>
+        /// <param name="OSRegistryFile"></param>
+        /// <param name="scriptsFile"></param>
+        public ConfigParser(string guidsFile, string OSRegistryFile, string scriptsFile)
+        {
+            UpdateKnownGUIDS(guidsFile);
+            UpdateScripts(scriptsFile);
+            OsVersion = getLiveOSVersion();
+            this.OSRegistryFile = OSRegistryFile;
+        }
+
 
 
         /// <summary>
@@ -32,6 +48,16 @@ namespace SeeShells.ShellParser
             foreach(GUIDPair pair in guidPairs)
             {   
                 KnownGuids.dict[pair.getKnownGUID().Key] = pair.getKnownGUID().Value;
+            }
+
+        }
+
+        private void UpdateScripts(string file)
+        {
+            IList<ScriptPair> scriptPairs = JsonConvert.DeserializeObject<IList<ScriptPair>>(File.ReadAllText(file));
+            foreach(ScriptPair pair in scriptPairs)
+            {
+                ScriptHandler.scripts[pair.getScript().Key] = pair.getScript().Value;   
             }
 
         }

--- a/WPF/SeeShells/SeeShells/ShellParser/Scripting/LuaShellItem.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Scripting/LuaShellItem.cs
@@ -32,9 +32,6 @@ namespace SeeShells.ShellParser.Scripting
             {
                 // it seems like this exception happens when there's an issue with a DLL or reference file.
                 // occurs on state = new Lua();
-                // on stackoverflow, it seems to mostly happen when mixing x86 and x64 stuff
-                // not really what to do here; this error has only popped up for me when running the tests
-                // maybe it's something with the way it's building? https://github.com/NLua/NLua/issues/67
 
                 skipParsing = true;
             }
@@ -57,10 +54,6 @@ namespace SeeShells.ShellParser.Scripting
                 return GetString("Name");
             }
         }
-
-        public string test()
-        { return "test"; }
-
 
         public override DateTime ModifiedDate
         {
@@ -167,7 +160,6 @@ namespace SeeShells.ShellParser.Scripting
             }
             catch (Exception ex)
             {
-                // since someone might add their own scripts, they should be able to see the errors right?
                 logger.Error(ex, "Error with a Lua script.\n" + ex.ToString());
             }
 

--- a/WPF/SeeShells/SeeShells/ShellParser/Scripting/LuaShellItem.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Scripting/LuaShellItem.cs
@@ -179,6 +179,17 @@ namespace SeeShells.ShellParser.Scripting
         // the block functions are protected & they need to be public to be used by Lua.
         // These have the same functionality, but now Lua scripts can use these functions.
 
+        public new byte unpack_byte(int off)
+        {
+            try
+            {
+                return buf[offset + off];
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
         public new ushort unpack_word(int off)
         {
             try

--- a/WPF/SeeShells/SeeShells/ShellParser/Scripting/LuaShellItem.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Scripting/LuaShellItem.cs
@@ -1,0 +1,315 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SeeShells.ShellParser.ShellItems;
+using NLua;
+
+namespace SeeShells.ShellParser.Scripting
+{
+    public class LuaShellItem : ShellItem
+    {
+        private readonly Lua state;
+        private readonly string luascript;
+        Dictionary<string, string> properties = new Dictionary<string, string>();
+        private bool skipParsing = false;
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+        public LuaShellItem(byte[] buf, string luascript) : base(buf)
+        {
+            try
+            {
+                state = new Lua();
+                state.LoadCLRPackage();
+                state.DoString(@" import ('System', 'SeeShells', 'SeeShells.ShellParser.ShellItems', 'SeeShells.ShellParser') ");
+                state["properties"] = properties;
+                state["shellitem"] = this;
+                state["knownGUIDs"] = KnownGuids.dict;
+                this.luascript = luascript;
+            }
+            catch (BadImageFormatException)
+            {
+                // it seems like this exception happens when there's an issue with a DLL or reference file.
+                // occurs on state = new Lua();
+                // on stackoverflow, it seems to mostly happen when mixing x86 and x64 stuff
+                // not really what to do here; this error has only popped up for me when running the tests
+                // maybe it's something with the way it's building? https://github.com/NLua/NLua/issues/67
+
+                skipParsing = true;
+            }
+
+        }
+
+        public override string TypeName
+        {
+            get
+            {
+                return GetString("TypeName");
+            }
+        }
+
+
+        public override string Name
+        {
+            get
+            {
+                return GetString("Name");
+            }
+        }
+
+        public string test()
+        { return "test"; }
+
+
+        public override DateTime ModifiedDate
+        {
+            get
+            {
+                return GetDate("ModifiedDate");
+            }
+        }
+
+        public override DateTime AccessedDate
+        {
+            get
+            {
+                return GetDate("AccessedDate");
+            }
+        }
+
+        public override DateTime CreationDate
+        {
+            get
+            {
+                return GetDate("CreationDate");
+            }
+        }
+
+        private string GetString(string propertyName)
+        {
+            string result;
+
+            if (!PropertiesAreParsedAlready())
+                return null;
+
+            try
+            {
+                GetAllProperties().TryGetValue(propertyName, out string typename);
+                result = typename;
+            }
+            catch (ArgumentNullException)
+            {
+                result = "";
+            }
+
+            return result;
+        }
+
+        private DateTime GetDate(string propertyName)
+        {
+            DateTime date;
+
+            if (!PropertiesAreParsedAlready())
+                return DateTime.MinValue;
+
+            try
+            {
+                GetAllProperties().TryGetValue(propertyName, out string dateString);
+                date = DateTime.Parse(dateString);
+            }
+            catch (ArgumentNullException)
+            {
+                date = DateTime.MinValue;
+            }
+            catch (FormatException)
+            {
+                date = DateTime.MinValue;
+            }
+
+            return date;
+        }
+
+        public override IDictionary<string, string> GetAllProperties()
+        {
+            if (!PropertiesAreParsedAlready())
+            {
+                var prop = base.GetAllProperties();
+                ParseShellItem();
+            }
+
+            return properties;
+        }
+
+        private bool PropertiesAreParsedAlready()
+        {
+            if (properties.Count > 0)
+                return true;
+
+            return false;
+        }
+
+        private void ParseShellItem()
+        {
+            if (skipParsing)
+                return;
+
+            if (luascript is null || luascript == "")
+                throw new Exception("No Lua script provided");
+
+            // better way to check for validity?
+            if (!luascript.Contains("properties:Add"))
+                throw new Exception("There is no properties table in this Lua script to get information from");
+
+            try
+            {
+                state.DoString(@luascript);
+            }
+            catch (Exception ex)
+            {
+                // since someone might add their own scripts, they should be able to see the errors right?
+                logger.Error(ex, "Error with a Lua script.\n" + ex.ToString());
+            }
+
+
+            state.Dispose();
+        }
+
+        // The rest of these function are taken from the block class because
+        // the block functions are protected & they need to be public to be used by Lua.
+        // These have the same functionality, but now Lua scripts can use these functions.
+
+        public new ushort unpack_word(int off)
+        {
+            try
+            {
+                return BitConverter.ToUInt16(buf, offset + off);
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
+        public new string unpack_guid(int off)
+        {
+            try
+            {
+                return string.Format("{0:x2}{1:x2}{2:x2}{3:x2}-{4:x2}{5:x2}-{6:x2}{7:x2}-{8:x2}{9:x2}-{10:x2}{11:x2}{12:x2}{13:x2}{14:x2}{15:x2}",
+                    buf[offset + off + 3], buf[offset + off + 2], buf[offset + off + 1], buf[offset + off],
+                    buf[offset + off + 5], buf[offset + off + 4],
+                    buf[offset + off + 7], buf[offset + off + 6],
+                    buf[offset + off + 8], buf[offset + off + 9],
+                    buf[offset + off + 10], buf[offset + off + 11], buf[offset + off + 12], buf[offset + off + 13], buf[offset + off + 14], buf[offset + off + 15]);
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
+        public new string unpack_wstring(int off, int length = 0)
+        {
+            try
+            {
+                if (length == 0)
+                {
+                    int end = offset + off;
+                    for (int ind = offset + off; ind + 1 < buf.Length; ind += 2)
+                    {
+                        if (buf[ind] == 0 && buf[ind + 1] == 0)
+                        {
+                            end = ind;
+                            break;
+                        }
+                    }
+                    length = end - offset - off;
+                }
+                while (buf[offset + off + length - 2] == 0 && buf[offset + off + length - 1] == 0) length -= 2;
+                return Encoding.Unicode.GetString(buf, offset + off, length);
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
+        public new string unpack_string(int off, int length = 0)
+        {
+            try
+            {
+                if (length == 0)
+                {
+                    int end = Array.IndexOf(buf, (byte)0, offset + off);
+                    length = end - offset - off;
+                    if (length == 0) return string.Empty;
+                }
+                while (buf[offset + off + length - 1] == 0) --length;
+                return Encoding.ASCII.GetString(buf, offset + off, length);
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
+        public new uint unpack_dword(int off)
+        {
+            try
+            {
+                return BitConverter.ToUInt32(buf, offset + off);
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
+        public new ulong UnpackQword(int off)
+        {
+            try
+            {
+                return BitConverter.ToUInt64(buf, offset + off);
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
+        public new DateTime unpack_dosdate(int off)
+        {
+            try
+            {
+                ushort dosdate = (ushort)(buf[offset + off + 1] << 8 | buf[offset + off]);
+                ushort dostime = (ushort)(buf[offset + off + 3] << 8 | buf[offset + off + 2]);
+
+                //check if the bytes contained no data
+                if ((dosdate == 0 || dosdate == 1) && dostime == 0)
+                {
+                    return DateTime.MinValue; //same thing as invalid. (minvalue goes below the epoch)
+                }
+
+                int day = dosdate & 0x1F;
+                int month = (dosdate & 0x1E0) >> 5;
+                int year = (dosdate & 0xFE00) >> 9;
+                year += 1980;
+
+                int sec = (dostime & 0x1F) * 2;
+                int minute = (dostime & 0x7E0) >> 5;
+                int hour = (dostime & 0xF800) >> 11;
+
+                return new DateTime(year, month, day, hour, minute, sec);
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw new OverrunBufferException(offset + off, buf.Length);
+            }
+        }
+        public new DateTime UnpackFileTime(int off)
+        {
+            return DateTime.FromFileTimeUtc(BitConverter.ToInt64(buf, offset + off));
+        }
+        public new int align(int off, int alignment)
+        {
+            if (off % alignment == 0)
+                return off;
+            return off + (alignment - off % alignment);
+        }
+
+    }
+}

--- a/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
@@ -34,26 +34,5 @@ namespace SeeShells.ShellParser.Scripting
             return new LuaShellItem(buf, script);
 
         }
-
-        private static void GetScriptsTest()
-        {
-            // see if the scripts works with a control panel shell item
-            string LuaScript = @"         
-                local guid = shellitem:unpack_guid(0x0E)
-                local flag = shellitem:unpack_byte(0x03)
-                properties:Add(""TypeName"", ""Control Panel"")
-                properties:Add(""Guid"", tostring(guid))
-                properties:Add(""Flags"", tostring(flag))
-                if knownGUIDs:ContainsKey(tostring(guid)) then
-                    properties:Add(""Name"", string.format(""{{CONTROL PANEL: %s}}"", knownGUIDs[guid]))
-                else
-                    properties:Add(""Name"", string.format(""{{CONTROL PANEL: %s}}"", guid))
-                end
-            ";
-
-            scripts.Add(Int32.Parse("71", System.Globalization.NumberStyles.HexNumber), LuaScript);
-        }
-
-
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
@@ -8,32 +8,26 @@ using SeeShells.ShellParser.ShellItems;
 namespace SeeShells.ShellParser.Scripting
 {
 
-    public class ScriptHandler
+    public static class ScriptHandler
     {
         /// <summary>
         /// A dictionary of key value pairs to store the scripts.
         /// The key is an int for the shell item identifier.
         /// The value is a string for the content of the script.
         /// </summary>
-        private readonly Dictionary<int, string> scripts = new Dictionary<int, string>();
+        public static Dictionary<int, string> scripts { get; set; }
 
-        public ScriptHandler()
+        static ScriptHandler()
         {
-            GetScriptsTest();
+            scripts = new Dictionary<int, string>();
         }
 
-        public void GetScripts(string fileLocation)
-        {
-            // get scripts from the configuration file & store them in scripts dictionary
-            throw new NotImplementedException();
-        }
-
-        public bool HasScriptForShellItem(int identifier)
+        public static bool HasScriptForShellItem(int identifier)
         {
             return scripts.ContainsKey(identifier);
         }
 
-        public IShellItem ParseShellItem(byte[] buf, int identifier)
+        public static IShellItem ParseShellItem(byte[] buf, int identifier)
         {
             scripts.TryGetValue(identifier, out string script);
 
@@ -41,7 +35,7 @@ namespace SeeShells.ShellParser.Scripting
 
         }
 
-        private void GetScriptsTest()
+        private static void GetScriptsTest()
         {
             // see if the scripts works with a control panel shell item
             string LuaScript = @"         

--- a/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SeeShells.ShellParser.ShellItems;
+
+namespace SeeShells.ShellParser.Scripting
+{
+
+    public class ScriptHandler
+    {
+        /// <summary>
+        /// A dictionary of key value pairs to store the scripts.
+        /// The key is an int for the shell item identifier.
+        /// The value is a string for the content of the script.
+        /// </summary>
+        private readonly Dictionary<int, string> scripts = new Dictionary<int, string>();
+
+        public ScriptHandler()
+        {
+            GetScriptsTest();
+        }
+
+        public void GetScripts(string fileLocation)
+        {
+            // get scripts from the configuration file & store them in scripts dictionary
+            throw new NotImplementedException();
+        }
+
+        public bool HasScriptForShellItem(int identifier)
+        {
+            return scripts.ContainsKey(identifier);
+        }
+
+        public IShellItem ParseShellItem(byte[] buf, int identifier)
+        {
+            scripts.TryGetValue(identifier, out string script);
+
+            return new LuaShellItem(buf, script);
+
+        }
+
+        private void GetScriptsTest()
+        {
+            // see if the scripts works with a control panel shell item
+            string LuaScript = @"         
+                local guid = shellitem:unpack_guid(0x0E)
+                local flag = shellitem:unpack_byte(0x03)
+                properties:Add(""TypeName"", ""Control Panel"")
+                properties:Add(""Guid"", tostring(guid))
+                properties:Add(""Flags"", tostring(flag))
+                if knownGUIDs:ContainsKey(tostring(guid)) then
+                    properties:Add(""Name"", string.format(""{{CONTROL PANEL: %s}}"", knownGUIDs[guid]))
+                else
+                    properties:Add(""Name"", string.format(""{{CONTROL PANEL: %s}}"", guid))
+                end
+            ";
+
+            scripts.Add(Int32.Parse("71", System.Globalization.NumberStyles.HexNumber), LuaScript);
+        }
+
+
+    }
+}

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SeeShells.ShellParser.Scripting;
 using System.Collections.Generic;
 
 namespace SeeShells.ShellParser.ShellItems
@@ -28,9 +29,9 @@ namespace SeeShells.ShellParser.ShellItems
             { 
                 // if we have a script for the ShellItem, use it to get the information needed
                 int identifier = unpack_byte(off + 2);
-                if (App.Scripts.HasScriptForShellItem(identifier))
+                if (ScriptHandler.HasScriptForShellItem(identifier))
                 {
-                    return App.Scripts.ParseShellItem(buf, identifier);
+                    return ScriptHandler.ParseShellItem(buf, identifier);
                 }
 
                 // Getting here means that the ShellItem is unidentified

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
@@ -29,9 +29,22 @@ namespace SeeShells.ShellParser.ShellItems
             { 
                 // if we have a script for the ShellItem, use it to get the information needed
                 int identifier = unpack_byte(off + 2);
+
                 if (ScriptHandler.HasScriptForShellItem(identifier))
                 {
-                    return ScriptHandler.ParseShellItem(buf, identifier);
+                    try
+                    {
+                        return ScriptHandler.ParseShellItem(buf, identifier);
+                    }
+                    catch (ArgumentNullException)
+                    {
+                        logger.Error("The identifier being passed to the Lua scripts is null.");
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error("Failed to parse shell item through script: " + ex.Message);
+                    }
+
                 }
 
                 // Getting here means that the ShellItem is unidentified

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
@@ -24,13 +24,18 @@ namespace SeeShells.ShellParser.ShellItems
             String postfix = unpack_byte(off + 2).ToString("X2");
 
             Type type = Type.GetType("SeeShells.ShellParser.ShellItems.ShellItem0x" + postfix);
-            if(type == null)
-            {
+            if (type == null || type == Type.GetType("SeeShells.ShellParser.ShellItems.ShellItem0x71"))
+            { 
+                // if we have a script for the ShellItem, use it to get the information needed
+                int identifier = unpack_byte(off + 2);
+                if (App.Scripts.HasScriptForShellItem(identifier))
+                {
+                    return App.Scripts.ParseShellItem(buf, identifier);
+                }
+
                 // Getting here means that the ShellItem is unidentified
                 logger.Info("Could not identify ShellItem 0x" + postfix);
                 return new ShellItem(buf);
-
-                // TODO Embedded Scripting
             }
 
             try

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItemList.cs
@@ -25,7 +25,7 @@ namespace SeeShells.ShellParser.ShellItems
             String postfix = unpack_byte(off + 2).ToString("X2");
 
             Type type = Type.GetType("SeeShells.ShellParser.ShellItems.ShellItem0x" + postfix);
-            if (type == null || type == Type.GetType("SeeShells.ShellParser.ShellItems.ShellItem0x71"))
+            if (type == null)
             { 
                 // if we have a script for the ShellItem, use it to get the information needed
                 int identifier = unpack_byte(off + 2);

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -269,10 +269,6 @@ namespace SeeShells.UI.Pages
             //begin the parsing process
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
-
-            // uncomment the below line when actually getting the script file
-            // App.Scripts.GetScripts(locations.ScriptFileLocation);
-
             App.ShellItems = await ParseShellBags();
             List<IEvent> events = EventParser.GetEvents(App.ShellItems);
             App.nodeCollection.nodeList.AddRange(NodeParser.GetNodes(events));

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -171,9 +171,32 @@ namespace SeeShells.UI.Pages
             }
         }
 
-        private void ScriptUpdateButton_Click(object sender, RoutedEventArgs e)
+        private async void ScriptUpdateButton_Click(object sender, RoutedEventArgs e)
         {
-            MessageBox.Show("Scripting is still a work in progress.", "Check back later.", MessageBoxButton.OK, MessageBoxImage.Information);
+            string location = locations.ScriptFileLocation;
+            if (!ContinueAfterSendingOverwriteWarning(location))
+                return;
+
+            string message = "File saved at\n" + location;
+            string caption = "Success";
+            MessageBoxImage image = MessageBoxImage.Information;
+
+            try
+            {
+                Mouse.OverrideCursor = Cursors.Wait;
+
+                await Task.Run(() => API.GetScripts(location));
+
+            }
+            catch (APIException)
+            {
+                message = "Failed to save the Scripts configuration file.";
+                caption = "Fail";
+                image = MessageBoxImage.Error;
+            }
+
+            Mouse.OverrideCursor = Cursors.Arrow;
+            MessageBox.Show(message, caption, MessageBoxButton.OK, image);
         }
 
         private bool ContinueAfterSendingOverwriteWarning(string path)

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -246,6 +246,10 @@ namespace SeeShells.UI.Pages
             //begin the parsing process
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
+
+            // uncomment the below line when actually getting the script file
+            // App.Scripts.GetScripts(locations.ScriptFileLocation);
+
             App.ShellItems = await ParseShellBags();
             List<IEvent> events = EventParser.GetEvents(App.ShellItems);
             App.nodeCollection.nodeList.AddRange(NodeParser.GetNodes(events));

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -274,7 +274,12 @@ namespace SeeShells.UI.Pages
             { 
 
                 List<IShellItem> retList = new List<IShellItem>();
-                ConfigParser parser = new ConfigParser(locations.GUIDFileLocation, locations.OSFileLocation);
+
+                ConfigParser parser;
+                if (File.Exists(locations.ScriptFileLocation))
+                    parser = new ConfigParser(locations.GUIDFileLocation, locations.OSFileLocation, locations.ScriptFileLocation);
+                else
+                    parser = new ConfigParser(locations.GUIDFileLocation, locations.OSFileLocation);
 
                 //perform offline shellbag parsing
                 if (useRegistryHiveFiles)


### PR DESCRIPTION
Resolves #147 
The code added in the IO Networking folder covers this part. The API endpoint is hit, and the JSON object's base64 scripts are decoded when de-serialized the first time for making the configuration file. The other times the JSON is de-serialized (reading from this file), a decoded scripts pair class is used so that it doesn't attempt to decode the scripts again.

Resolves #148 
The code uses the actual scripts.json configuration file instead of hard-coded scripts I had earlier in the program to test it out.

Resolves #79 
Control Panel Shell item script worked when used through the configuration file (like it did when it was used in my little test function within the program earlier this week). With how the code is written now, you won't see the script used since I took out the check for the 0x71 identifier. I did this since the script was just a proof of concept and so that the existing control panel shell item class can be used properly.