### PR TITLE
Adds Offline username retrieval support

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
@@ -82,7 +82,16 @@ namespace SeeShells.ShellParser
 
             return locations;
         }
-        
+
+        public List<string> GetUsernameLocations()
+        {
+            //todo retrieve from OSRegistryFile instead of hardcoded path
+            List<string> list = new List<string>();
+            // found username retrievalable key-value @ https://stackoverflow.com/a/53585223
+            list.Add(@"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders");
+            return list;
+        }
+
         private string getLiveOSVersion()
         {
             RegistryKey registryKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("Software\\Microsoft\\Windows NT\\CurrentVersion");

--- a/WPF/SeeShells/SeeShells/ShellParser/IConfigParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/IConfigParser.cs
@@ -8,5 +8,7 @@ namespace SeeShells.ShellParser
     {
         List<string> GetRegistryLocations();
 
+        List<string> GetUsernameLocations();
+
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
@@ -43,14 +43,12 @@ namespace SeeShells.ShellParser.Registry
                 {
                     foreach (byte[] keyValue in IterateRegistry(userStore.OpenSubKey(location), location, 0, ""))
                     {
-                        retList.Add(new RegistryKeyWrapper(keyValue));
+                        var keyWrapper = new RegistryKeyWrapper(keyValue);
+                        keyWrapper.RegistryUser = userStore.Name.Split('\\').Last(); //only pull the SID, dont include HKEY_USERS\
+
+                        retList.Add(keyWrapper);
                     }
                 }
-                foreach (RegistryKeyWrapper keyWrapper in retList)
-                {
-                    keyWrapper.RegistryUser = userStore.Name.Split('\\').Last(); //only pull the SID, dont include HKEY_USERS\
-                }
-                //possible separation of RegistryKeyWrappers by user is also possible above.
             }
 
             return retList;

--- a/WPF/SeeShells/SeeShellsTests/ShellParser/ShellBagParserTests.cs
+++ b/WPF/SeeShells/SeeShellsTests/ShellParser/ShellBagParserTests.cs
@@ -34,6 +34,12 @@ namespace SeeShellsTests.ShellParser
             List<IShellItem> shellItems = ShellBagParser.GetShellItems(new OfflineRegistryReader(new OfflineMockConfigParser(), registryFilePath));
 
             Assert.AreNotEqual(shellItems.Count, 0);
+
+            //test for username presence in the shellItems
+            foreach (IShellItem shellItem in shellItems)
+            {
+                Assert.AreEqual("Klayton", shellItem.GetAllProperties()["RegistryOwner"]);
+            }
         }
     }
 }

--- a/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/MockConfigParser.cs
+++ b/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/MockConfigParser.cs
@@ -18,5 +18,13 @@ namespace SeeShellsTests.ShellParser.ShellParserMocks
             list.Add("Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell");
             return list;
         }
+
+        public List<string> GetUsernameLocations()
+        {
+            List<String> list = new List<String>();
+            list.Add("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders");
+            return list;
+
+        }
     }
 }

--- a/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/OfflineMockConfigParser.cs
+++ b/WPF/SeeShells/SeeShellsTests/ShellParser/ShellParserMocks/OfflineMockConfigParser.cs
@@ -16,5 +16,12 @@ namespace SeeShellsTests.ShellParser.ShellParserMocks
             list.Add(@"Software\Microsoft\Windows\Shell");
             return list;
         }
+
+        public List<string> GetUsernameLocations()
+        {
+            List<String> list = new List<String>();
+            list.Add(@"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders");
+            return list;
+        }
     }
 }


### PR DESCRIPTION
- Fixes Online username error of setting last username to all values
- temporarily adds hardcoded username retrieval value which needs to be expanded upon

Resolves #164 However new issues/improvements need to be made. 
Specifically:
- Offline username retrieval is currently done through a hardcoded value which will only work on vista+ this value/potential keys that contain the username need to be added to a configuration.
- online username currently retrieve SID's because they are guaranteed and its non-trivial to resolve SID's to usernames without the SAM registry hive. Therefore live parsing should use the same username locations as offline and fallback to SID's when not available. 