### PR TITLE
Filterable timeline

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
@@ -1,9 +1,6 @@
 ﻿using SeeShells.UI.EventFilters;
-using System;
+using SeeShells.UI.Pages;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SeeShells.UI.Node
 {
@@ -28,6 +25,7 @@ namespace SeeShells.UI.Node
         {
             filterList.Add(identifier, filter);
             filter.Apply(ref nodeList);
+            TimelinePage.timelinePage.RebuildTimeline();
         }
 
         /// <summary>
@@ -51,6 +49,7 @@ namespace SeeShells.UI.Node
                 {
                     filter.Apply(ref nodeList);
                 }
+                TimelinePage.timelinePage.RebuildTimeline();
             }
         }
 

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
@@ -25,7 +25,7 @@ namespace SeeShells.UI.Node
         {
             filterList.Add(identifier, filter);
             filter.Apply(ref nodeList);
-            TimelinePage.timelinePage.RebuildTimeline();
+            Home.timelinePage.RebuildTimeline();
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace SeeShells.UI.Node
                 {
                     filter.Apply(ref nodeList);
                 }
-                TimelinePage.timelinePage.RebuildTimeline();
+                Home.timelinePage.RebuildTimeline();
             }
         }
 

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
@@ -1,5 +1,4 @@
 ﻿using SeeShells.UI.EventFilters;
-using SeeShells.UI.Pages;
 using System.Collections.Generic;
 
 namespace SeeShells.UI.Node
@@ -25,7 +24,6 @@ namespace SeeShells.UI.Node
         {
             filterList.Add(identifier, filter);
             filter.Apply(ref nodeList);
-            Home.timelinePage.RebuildTimeline();
         }
 
         /// <summary>
@@ -49,7 +47,6 @@ namespace SeeShells.UI.Node
                 {
                     filter.Apply(ref nodeList);
                 }
-                Home.timelinePage.RebuildTimeline();
             }
         }
 

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -30,6 +30,8 @@ namespace SeeShells.UI.Pages
 
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
+        public static TimelinePage timelinePage;
+
         public Home()
         {
             InitializeComponent();
@@ -282,14 +284,15 @@ namespace SeeShells.UI.Pages
 
             //Go to Timeline            
             Mouse.OverrideCursor = Cursors.Arrow;
-            if(TimelinePage.timelinePage == null)
+            if(timelinePage == null)
             {
-                NavigationService.Navigate(new TimelinePage());
+                timelinePage = new TimelinePage();
+                NavigationService.Navigate(timelinePage);
             }
             else
             {
-                TimelinePage.timelinePage.RebuildTimeline();
-                NavigationService.Navigate(TimelinePage.timelinePage);
+                timelinePage.RebuildTimeline();
+                NavigationService.Navigate(timelinePage);
             }
             
 

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -282,7 +282,16 @@ namespace SeeShells.UI.Pages
 
             //Go to Timeline            
             Mouse.OverrideCursor = Cursors.Arrow;
-            NavigationService.Navigate(new TimelinePage());
+            if(TimelinePage.timelinePage == null)
+            {
+                NavigationService.Navigate(new TimelinePage());
+            }
+            else
+            {
+                TimelinePage.timelinePage.RebuildTimeline();
+                NavigationService.Navigate(TimelinePage.timelinePage);
+            }
+            
 
         }
 

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -30,7 +30,7 @@ namespace SeeShells.UI.Pages
 
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-        public static TimelinePage timelinePage;
+        private TimelinePage timelinePage;
 
         public Home()
         {

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Win32;
 using SeeShells.IO;
 using SeeShells.UI.EventFilters;
+using SeeShells.UI.Node;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,11 +26,12 @@ namespace SeeShells.UI.Pages
 
         private TimeSpan maxRealTimeSpan = new TimeSpan(0, 0, 1, 0); // Max time in one timeline (1 min).
 
+        public static TimelinePage timelinePage;
         public TimelinePage()
         {
             InitializeComponent();
-
             BuildTimeline();
+            timelinePage = this;
         }
 
         private void AllStringFilter_TextChanged(object sender, TextChangedEventArgs e)
@@ -142,7 +144,7 @@ namespace SeeShells.UI.Pages
         /// <summary>
         /// Builds a timeline dynamically. Creates one timeline for each cluster of events.
         /// </summary>
-        public void BuildTimeline()
+        private void BuildTimeline()
         {
             try
             {
@@ -152,25 +154,40 @@ namespace SeeShells.UI.Pages
                     return;
                 }
 
+                List<Node.Node> nodeList = new List<Node.Node>();
+                foreach (Node.Node node in App.nodeCollection.nodeList)
+                {
+                    if(node.dot.Visibility == System.Windows.Visibility.Visible)
+                    {
+                        nodeList.Add(node);
+                    }
+                }
+
+                if (nodeList.Count == 0)
+                {
+                    logger.Info("All nodes are filtered out, no nodes to draw on the timeline.");
+                    return;
+                }
+
                 List<Node.Node> nodesCluster = new List<Node.Node>(); // Holds events for one timeline at a time.
-                nodesCluster.Add(App.nodeCollection.nodeList[0]);
-                DateTime previousDate = App.nodeCollection.nodeList[0].aEvent.EventTime;
+                nodesCluster.Add(nodeList[0]);
+                DateTime previousDate = nodeList[0].aEvent.EventTime;
                 DateTime realTimeStart = DateTimeRoundDown(previousDate, maxRealTimeSpan);
-                int nodeListSize = App.nodeCollection.nodeList.Count;
+                int nodeListSize = nodeList.Count;
                 for (int i = 1; i < nodeListSize; i++)
                 {
                     // If the event belongs to the timeline
-                    if (TimeSpan.Compare(App.nodeCollection.nodeList[i].aEvent.EventTime.Subtract(realTimeStart), maxRealTimeSpan) == -1) // Compare returns -1 if the first argument is less than the second
+                    if (TimeSpan.Compare(nodeList[i].aEvent.EventTime.Subtract(realTimeStart), maxRealTimeSpan) == -1) // Compare returns -1 if the first argument is less than the second
                     {
-                        nodesCluster.Add(App.nodeCollection.nodeList[i]);
+                        nodesCluster.Add(nodeList[i]);
                     }
                     else
                     {
                         AddTimeline(nodesCluster);
                         nodesCluster.Clear();
 
-                        nodesCluster.Add(App.nodeCollection.nodeList[i]);
-                        previousDate = App.nodeCollection.nodeList[i].aEvent.EventTime;
+                        nodesCluster.Add(nodeList[i]);
+                        previousDate = nodeList[i].aEvent.EventTime;
                         realTimeStart = DateTimeRoundDown(previousDate, maxRealTimeSpan);
                         if (i == nodeListSize - 1) // If it's the last event of nodeList.
                         {
@@ -209,6 +226,7 @@ namespace SeeShells.UI.Pages
                 KeepOriginalOrderForOverlap = true
             };
 
+
             foreach (Node.Node node in nodesCluster)
             {
                 TimelinePanel.SetDate(node.dot, node.aEvent.EventTime);
@@ -245,6 +263,20 @@ namespace SeeShells.UI.Pages
         {
             long ticks = date.Ticks / roundingFactor.Ticks;
             return new DateTime(ticks * roundingFactor.Ticks);
+        }
+
+        /// <summary>
+        /// Clears the children of all timeline related UI objects and builds timeline.
+        /// </summary>
+        public void RebuildTimeline()
+        {
+            foreach(TimelinePanel timeline in Timelines.Children)
+            {
+                timeline.Children.Clear();
+            }
+            Timelines.Children.Clear();
+            TimeStamps.Children.Clear();
+            BuildTimeline();
         }
 
         /// <summary>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -26,12 +26,10 @@ namespace SeeShells.UI.Pages
 
         private TimeSpan maxRealTimeSpan = new TimeSpan(0, 0, 1, 0); // Max time in one timeline (1 min).
 
-        public static TimelinePage timelinePage;
         public TimelinePage()
         {
             InitializeComponent();
             BuildTimeline();
-            timelinePage = this;
         }
 
         private void AllStringFilter_TextChanged(object sender, TextChangedEventArgs e)

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Win32;
 using SeeShells.IO;
 using SeeShells.UI.EventFilters;
-using SeeShells.UI.Node;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -56,6 +55,8 @@ namespace SeeShells.UI.Pages
             //add a new filter with our date restrictions
             App.nodeCollection.AddEventFilter(filterIdentifer, newFilter);
 
+            //rebuild the timeline according to the new filters
+            this.RebuildTimeline();
         }
 
         /// <summary>


### PR DESCRIPTION
The timeline is rebuilt every time a filter is applied or removed.
The rebuilt timeline only contains events that have not been filtered out and scales according to those events. 
Also added a check to the parse button that checks if a timeline has been built previously, and it it has it rebuilds it.

Resolves #194.