### PR TITLE
Adds default configuration support to WPF

### DIFF
--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -235,6 +235,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <EmbeddedResource Include="resources\defaultOS.json" />
     <Resource Include="SeeShellsSolid.ico" />
     <Resource Include="SeeShells.ico" />
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ConfigParser.cs
@@ -1,35 +1,34 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
 using SeeShells.IO.Networking.JSON;
 using SeeShells.UI.ViewModels;
 using Microsoft.Win32;
+using NLog;
 using SeeShells.ShellParser.Scripting;
+using SeeShells.UI.Pages;
 
 namespace SeeShells.ShellParser
 {
     class ConfigParser : IConfigParser
     {
         private readonly string OSRegistryFile;
+        private const string DefaultOsConfig = "defaultOS.json";
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
 
         public string OsVersion {private get; set;}
 
-        public ConfigParser(string guidsFile, string OSRegistryFile)
+        public ConfigParser(string guidsFile = "", string OSRegistryFile = "", string scriptsFile = "")
         {
-            UpdateKnownGUIDS(guidsFile);
-            OsVersion = getLiveOSVersion();
-            this.OSRegistryFile = OSRegistryFile;
-        }
-        /// <summary>
-        /// Scripts are optional, so use this constructor when there is a selected scripts file.
-        /// </summary>
-        /// <param name="guidsFile"></param>
-        /// <param name="OSRegistryFile"></param>
-        /// <param name="scriptsFile"></param>
-        public ConfigParser(string guidsFile, string OSRegistryFile, string scriptsFile)
-        {
+            guidsFile = IsValidGuidFile(guidsFile) ? guidsFile : string.Empty;
+            OSRegistryFile = IsValidOsFile(OSRegistryFile) ? OSRegistryFile : string.Empty;
+            scriptsFile = IsValidScriptFile(scriptsFile) ? scriptsFile : string.Empty;
+
             UpdateKnownGUIDS(guidsFile);
             UpdateScripts(scriptsFile);
             OsVersion = getLiveOSVersion();
@@ -44,6 +43,9 @@ namespace SeeShells.ShellParser
         /// <param name="guidsFile">A JSON file that contains <see cref="GUIDPair"/></param>
         private void UpdateKnownGUIDS(string guidsFile)
         {
+            if (guidsFile.Equals(string.Empty))
+                return;
+
             IList<GUIDPair> guidPairs = JsonConvert.DeserializeObject<IList<GUIDPair>>(File.ReadAllText(guidsFile));
             foreach(GUIDPair pair in guidPairs)
             {   
@@ -54,6 +56,9 @@ namespace SeeShells.ShellParser
 
         private void UpdateScripts(string file)
         {
+            if (file.Equals(string.Empty))
+                return;
+
             IList<DecodedScriptPair> scriptPairs = JsonConvert.DeserializeObject<IList<DecodedScriptPair>>(File.ReadAllText(file));
             foreach(DecodedScriptPair pair in scriptPairs)
             {
@@ -67,7 +72,10 @@ namespace SeeShells.ShellParser
         {
             List<string> locations = new List<string>();
 
-            IList<RegistryLocations> registryLocations = JsonConvert.DeserializeObject<IList<RegistryLocations>>(File.ReadAllText(OSRegistryFile));
+            IList<RegistryLocations> registryLocations = OSRegistryFile.Equals(string.Empty)
+                ? GetDefaultRegistryLocations()
+                : JsonConvert.DeserializeObject<IList<RegistryLocations>>(File.ReadAllText(OSRegistryFile));
+
             foreach (RegistryLocations regLocation in registryLocations)
             {
                 if (OsVersion.Contains(regLocation.OperatingSystem))
@@ -96,6 +104,78 @@ namespace SeeShells.ShellParser
         {
             RegistryKey registryKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("Software\\Microsoft\\Windows NT\\CurrentVersion");
             return (string)registryKey.GetValue("productName");   
+        }
+
+
+        /// <summary>
+        /// Retrieves the default <see cref="RegistryLocations"/> configuration from the embedded resource.
+        /// </summary>
+        /// <returns>A list of Registry Locations.</returns>
+        public static IList<RegistryLocations> GetDefaultRegistryLocations()
+        {
+            IList<RegistryLocations> retval = new List<RegistryLocations>();
+            try
+            {
+                //internal resource retrieval, see: https://stackoverflow.com/a/3314213
+                Assembly assembly = Assembly.GetExecutingAssembly();
+                string internalResourcePath = assembly.GetManifestResourceNames().Single(str => str.EndsWith(DefaultOsConfig));
+                using (Stream fileStream = assembly.GetManifestResourceStream(internalResourcePath))
+                {
+                    using (StreamReader reader = new StreamReader(fileStream))
+                    {
+                        retval = JsonConvert.DeserializeObject<IList<RegistryLocations>>(reader.ReadToEnd());
+                    }
+                }
+            }
+            catch (JsonSerializationException)
+            {
+                //this should never happen. if it does, we are somehow missing internal (compiled) resources or its malformed.
+                logger.Fatal("Cannot load default OS Configuration file. Internal resource is missing or broken." +
+                             " Please notify the developers with your error log and browse for a new OS Configuration file.");
+            }
+
+            return retval;
+        }
+
+        /// <summary>
+        /// Checks if a JSON file can be deserialized for a valid known Type
+        /// </summary>
+        /// <typeparam name="T">The known API Type to deserialize from. See <see cref="IO.Networking.JSON"/></typeparam>
+        /// <param name="location">a fully qualified path to a json file</param>
+        /// <returns>true, if the file could successfully be deserialized. False otherwise.</returns>
+        private static bool IsValidConfigFile<T>(string location)
+        {
+            if (File.Exists(location))
+            {
+                string json = File.ReadAllText(location);
+                try
+                {
+                    JsonConvert.DeserializeObject<T> (json);
+                    //if we can deserialize, we can use it.
+                    return true;
+                }
+                catch (JsonSerializationException ex)
+                {
+                    logger.Error(ex);
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool IsValidOsFile(string location)
+        {
+            return IsValidConfigFile<IList<RegistryLocations>>(location);
+        }
+        public static bool IsValidGuidFile(string location)
+        {
+            return IsValidConfigFile<IList<GUIDPair>>(location);
+        }
+
+        public static bool IsValidScriptFile(string location)
+        {
+            return IsValidConfigFile<IList<DecodedScriptPair>>(location);
         }
 
     }

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -15,6 +15,9 @@ using SeeShells.ShellParser.ShellItems;
 using SeeShells.ShellParser;
 using SeeShells.UI.Node;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using NLog.Time;
 using SeeShells.ShellParser.Registry;
 
 namespace SeeShells.UI.Pages
@@ -65,25 +68,29 @@ namespace SeeShells.UI.Pages
         {
             OSVersion.SelectedIndex = -1;
             OSVersion.Items.Clear();
-            OSVersion.Items.Add("Generic Windows");
 
-            if (!File.Exists(locations.OSFileLocation))
-                return;
+            IList<RegistryLocations> registryLocations = ConfigParser.GetDefaultRegistryLocations();
 
-            string json = File.ReadAllText(locations.OSFileLocation);
-            try
+            if (File.Exists(locations.OSFileLocation))
             {
-                IList<RegistryLocations> registryLocations = JsonConvert.DeserializeObject<IList<RegistryLocations>>(json);
-                foreach (RegistryLocations location in registryLocations)
+                string json = File.ReadAllText(locations.OSFileLocation);
+                try
                 {
-                    if (!OSVersion.Items.Contains(location.OperatingSystem))
-                        OSVersion.Items.Add(location.OperatingSystem);
+                    registryLocations = JsonConvert.DeserializeObject<IList<RegistryLocations>>(json);
+                }
+                catch (JsonSerializationException)
+                {
+                    showErrorMessage("The OS file selected is not formatted properly. Will proceed with default OS configurations.",
+                        "Incorrect OS Configuration File Format");
                 }
             }
-            catch (JsonSerializationException)
+
+            foreach (RegistryLocations location in registryLocations)
             {
-                showErrorMessage("The OS file you selected is not formatted properly.", "Incorrect OS Configuration File Format");
+                if (!OSVersion.Items.Contains(location.OperatingSystem))
+                    OSVersion.Items.Add(location.OperatingSystem);
             }
+
         }
 
         private void OSBrowseButton_Click(object sender, RoutedEventArgs e)
@@ -91,8 +98,7 @@ namespace SeeShells.UI.Pages
             string location = GetFileFromBrowsing();
             if(UserSelectedFile(location))
             {
-               locations.OSFileLocation = location;
-
+                locations.OSFileLocation = location;
                 UpdateOSVersionList();
             }
         }
@@ -123,6 +129,7 @@ namespace SeeShells.UI.Pages
 
             Mouse.OverrideCursor = Cursors.Arrow;
             MessageBox.Show(message, caption, MessageBoxButton.OK, image);
+            UpdateOSVersionList();
 
         }
 
@@ -296,11 +303,7 @@ namespace SeeShells.UI.Pages
 
                 List<IShellItem> retList = new List<IShellItem>();
 
-                ConfigParser parser;
-                if (File.Exists(locations.ScriptFileLocation))
-                    parser = new ConfigParser(locations.GUIDFileLocation, locations.OSFileLocation, locations.ScriptFileLocation);
-                else
-                    parser = new ConfigParser(locations.GUIDFileLocation, locations.OSFileLocation);
+                ConfigParser parser = new ConfigParser(locations.GUIDFileLocation, locations.OSFileLocation, locations.ScriptFileLocation);
 
                 //perform offline shellbag parsing
                 if (useRegistryHiveFiles)
@@ -326,15 +329,28 @@ namespace SeeShells.UI.Pages
 
         private bool ConfigurationFilesAreValid()
         {
-            if (!File.Exists(locations.OSFileLocation))
+            string messageBoxTitle = "Invalid configuration selected";
+            string question = "The currently selected {0} file is invalid or missing.\n" +
+                              "Would you like to proceed anyway?";
+
+            if (!ConfigParser.IsValidOsFile(locations.OSFileLocation))
             {
-                showErrorMessage("Select a proper OS configuration file or create a new one.", "Missing OS File");
-                return false;
+                MessageBoxResult result = AskYesNoQuestion(string.Format(question, "OS Configuration"), messageBoxTitle);
+                if (result != MessageBoxResult.Yes)
+                    return false;
             }
-            if (!File.Exists(locations.GUIDFileLocation))
+            if (!ConfigParser.IsValidGuidFile(locations.GUIDFileLocation))
             {
-                showErrorMessage("Select a proper GUID configuration file or create a new one.", "Missing GUID File");
-                return false;
+                MessageBoxResult result = AskYesNoQuestion(string.Format(question, "GUID Configuration"), messageBoxTitle);
+                if (result != MessageBoxResult.Yes)
+                    return false;
+            }
+            if (!ConfigParser.IsValidScriptFile(locations.ScriptFileLocation))
+            {
+                MessageBoxResult result = AskYesNoQuestion(string.Format(question, "Script Configuration"), messageBoxTitle);
+                if (result != MessageBoxResult.Yes)
+                    return false;
+
             }
 
             return true;
@@ -393,10 +409,14 @@ namespace SeeShells.UI.Pages
             OSVersionRow.Height = visibleRow;
         }
 
-        private void showErrorMessage(string message, string messageBoxTitle = "An Error Occurred")
+        private static void showErrorMessage(string message, string messageBoxTitle = "An Error Occurred")
         {
             logger.Warn(message);
             MessageBox.Show(message, messageBoxTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        private static MessageBoxResult AskYesNoQuestion(string message, string messageBoxTitle = "SeeShells")
+        {
+            return MessageBox.Show(message, messageBoxTitle, MessageBoxButton.YesNo, MessageBoxImage.Question);
         }
 
         private void EnableUIElements(bool value)

--- a/WPF/SeeShells/SeeShells/resources/defaultOS.json
+++ b/WPF/SeeShells/SeeShells/resources/defaultOS.json
@@ -1,0 +1,56 @@
+[
+  {
+    "os": "Windows XP",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\ShellNoRoam\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\ShellNoRoam\\Bags"
+    ]
+  },
+  {
+    "os": "Windows Vista",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+    ]
+  },
+  {
+    "os": "Windows 7",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+    ]
+  },
+  {
+    "os": "Windows 8",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+    ]
+  },
+  {
+    "os": "Windows 8.1",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+    ]
+  },
+  {
+    "os": "Windows 10",
+    "files": [
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "NTUSER.DAT\\Software\\Microsoft\\Windows\\Shell\\Bags",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU",
+      "UsrClass.dat\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags"
+    ]
+  }
+]


### PR DESCRIPTION
- Adds embedded OS Configuration file
- Adds Prompts for user confirmation on missing/invalid configs

No default config file needed for the following:
- GUID's:  already embedded with `KnownGUID` file
- Scripts: program works without scripts by default. (#140)

![bce8cea4-4031-489d-83ee-66cded8c9aee](https://user-images.githubusercontent.com/17878901/75640822-44ac7980-5c04-11ea-9eae-d72b532a29fd.gif)

Resolves #137 