### PR TITLE
Clear all filters on new parsing attempt

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeCollection.cs
@@ -1,5 +1,6 @@
 ﻿using SeeShells.UI.EventFilters;
 using System.Collections.Generic;
+using System.Windows;
 
 namespace SeeShells.UI.Node
 {
@@ -47,6 +48,15 @@ namespace SeeShells.UI.Node
                 {
                     filter.Apply(ref nodeList);
                 }
+            }
+        }
+
+        public void ClearAllFilters()
+        {
+            filterList.Clear();
+            foreach (var node in nodeList)
+            {
+                node.dot.Visibility = Visibility.Visible;
             }
         }
 

--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -274,6 +274,7 @@ namespace SeeShells.UI.Pages
             stopwatch.Start();
             App.ShellItems = await ParseShellBags();
             List<IEvent> events = EventParser.GetEvents(App.ShellItems);
+            App.nodeCollection.ClearAllFilters();
             App.nodeCollection.nodeList.AddRange(NodeParser.GetNodes(events));
             stopwatch.Stop();
             logger.Info("Parsing Complete. ShellItems Parsed: " + App.ShellItems.Count + ". Time Elapsed: " + stopwatch.ElapsedMilliseconds / 1000 + " seconds");

--- a/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
+++ b/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="ShellParser\ShellParserMocks\OfflineMockConfigParser.cs" />
     <Compile Include="UI\EventParserTest.cs" />
     <Compile Include="UI\EventCollectionTest.cs" />
+    <Compile Include="UI\Mocks\MockNodeFilter.cs" />
     <Compile Include="UI\NodeFilterTests.cs" />
     <Compile Include="UI\Mocks\MockEvent.cs" />
     <Compile Include="UI\Mocks\MockNode.cs" />

--- a/WPF/SeeShells/SeeShellsTests/UI/Mocks/MockNodeFilter.cs
+++ b/WPF/SeeShells/SeeShellsTests/UI/Mocks/MockNodeFilter.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using SeeShells.UI.EventFilters;
+using SeeShells.UI.Node;
+
+namespace SeeShellsTests.UI.Mocks
+{
+    /// <summary>
+    /// Filters out all but the specified nodes in the constructor
+    /// </summary>
+    public class MockNodeFilter : INodeFilter
+    {
+        private readonly Node[] acceptableNodes;
+
+        public MockNodeFilter(params Node[] acceptableNodes)
+        {
+            this.acceptableNodes = acceptableNodes;
+        }
+
+        public void Apply(ref List<Node> nodes)
+        {
+            foreach (Node node in nodes)
+            {
+                if (!acceptableNodes.Contains(node))
+                {
+                    node.dot.Visibility = Visibility.Collapsed;
+                }
+            }
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShellsTests/UI/NodeCollectionTest.cs
+++ b/WPF/SeeShells/SeeShellsTests/UI/NodeCollectionTest.cs
@@ -4,23 +4,51 @@ using SeeShells.UI;
 using SeeShells.UI.Node;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using SeeShellsTests.UI.Mocks;
 
 namespace SeeShellsTests.UI
 {
     [TestClass()]
     public class NodeCollectionTest
     {
+        private int CountVisible(IEnumerable<Node> nodes)
+        {
+            return (from node in nodes
+                where node.dot.Visibility == System.Windows.Visibility.Visible
+                select node).Count();
+        }
+
         /// <summary>
         /// Tests that a list of Nodes is created and saved in the NodeCollection object in App.xml.cs
         /// </summary>
         [TestMethod()]
-        public void NodeCollectionTests()
+        public void NodeCollectionCreationTest()
         {
             List<IEvent> eventList = new List<IEvent>();
-            Event aEvent = new Event("item1", DateTime.Now, null, "Access");
+            IEvent aEvent = new MockEvent("item1", DateTime.Now, null, "Access");
             eventList.Add(aEvent);
             App.nodeCollection.nodeList = NodeParser.GetNodes(eventList);
             Assert.AreNotEqual(App.nodeCollection.nodeList.Count, 0);
         }
+
+        [TestMethod()]
+        public void NodeCollectionClearAllTest()
+        {
+            IEvent event1 = new MockEvent("item1", DateTime.Now, null, "Access");
+            IEvent event2 = new MockEvent("item2", DateTime.Now, null, "Creation");
+            Node node1 = new MockNode(event1);
+            Node node2 = new MockNode(event2);
+
+            var nodeCollection = new NodeCollection {nodeList = new List<Node> {node1, node2}};
+
+            Assert.AreEqual(2, CountVisible(nodeCollection.nodeList));
+            nodeCollection.AddEventFilter("mockFilter", new MockNodeFilter(node1));
+            Assert.AreEqual(1, CountVisible(nodeCollection.nodeList));
+            nodeCollection.ClearAllFilters();
+            Assert.AreEqual(2, CountVisible(nodeCollection.nodeList));
+
+        }
+
     }
 }


### PR DESCRIPTION
- Adds unit test for new NodeCollection functionality
- improves isolation in existing NodeCollection test

Resolves #196 