### PR TITLE
Special character support for CSV Import/Export

### DIFF
--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -45,6 +45,9 @@
     <Reference Include="CommandLine">
       <HintPath>resources\CommandLine.dll</HintPath>
     </Reference>
+    <Reference Include="CsvHelper, Version=15.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsvHelper.15.0.1\lib\net45\CsvHelper.dll</HintPath>
+    </Reference>
     <Reference Include="KeraLua, Version=1.0.24.0, Culture=neutral, PublicKeyToken=6a194c04b9c89217, processorArchitecture=MSIL">
       <HintPath>..\packages\KeraLua.1.0.24\lib\net45\KeraLua.dll</HintPath>
     </Reference>
@@ -71,9 +74,18 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />

--- a/WPF/SeeShells/SeeShells/packages.config
+++ b/WPF/SeeShells/SeeShells/packages.config
@@ -1,11 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CsvHelper" version="15.0.1" targetFramework="net46" />
   <package id="Extended.Wpf.Toolkit" version="3.8.1" targetFramework="net46" />
   <package id="KeraLua" version="1.0.24" targetFramework="net46" />
+  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net46" />
   <package id="NLog" version="4.6.8" targetFramework="net46" />
   <package id="NLog.Config" version="4.6.8" targetFramework="net46" />
   <package id="NLog.Schema" version="4.6.8" targetFramework="net46" />
   <package id="NLua" version="1.4.27" targetFramework="net46" />
   <package id="RestSharp" version="106.10.1" targetFramework="net46" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/WPF/SeeShells/SeeShellsTests/IO/CsvIOTests.cs
+++ b/WPF/SeeShells/SeeShellsTests/IO/CsvIOTests.cs
@@ -47,5 +47,43 @@ namespace SeeShellsTests.IO
             List<IShellItem> shellItems = CsvIO.ImportCSVFile(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\raw.csv");
             Assert.AreNotEqual(shellItems.Count, 0);
         }
+
+        /// <summary>
+        /// Tests if CSV file with special characters is exported and imported correctly
+        /// </summary>
+        [TestMethod()]
+        public void ExportAndImportCSVWithSpecialCharactersTest()
+        {
+            // Export
+            List<IShellItem> shellItems = new List<IShellItem>();
+            Dictionary<string, string> shellItemProperties = new Dictionary<string, string>();
+            shellItemProperties.Add("Size", "0");
+            shellItemProperties.Add("Type", "31");
+            shellItemProperties.Add("TypeName", "Some Type Name");
+            shellItemProperties.Add("Name", "Some Name, \n \"Name\"");
+            shellItemProperties.Add("ModifiedDate", "1/1/0001 12:00:00 AM");
+            shellItemProperties.Add("AccessedDate", "1/1/0001 12:00:00 AM");
+            shellItemProperties.Add("CreationDate", "1/1/0001 12:00:00 AM");
+            CsvParsedShellItem ShellItem = new CsvParsedShellItem(shellItemProperties);
+            shellItems.Add(ShellItem);
+
+            if (File.Exists("raw.csv"))
+            {
+                File.Delete("raw.csv");
+            }
+            CsvIO.OutputCSVFile(shellItems, "raw.csv");
+            Assert.IsTrue(File.Exists("raw.csv"));
+
+            // Import
+            List<IShellItem> importedShellItems = CsvIO.ImportCSVFile("raw.csv");
+            IDictionary<string, string> allProperties = importedShellItems[0].GetAllProperties();
+            Assert.IsTrue(allProperties["Size"].Equals("0"));
+            Assert.IsTrue(allProperties["Type"].Equals("31"));
+            Assert.IsTrue(allProperties["TypeName"].Equals("Some Type Name"));
+            Assert.IsTrue(allProperties["Name"].Equals("Some Name, \n \"Name\""));
+            Assert.IsTrue(allProperties["ModifiedDate"].Equals("1/1/0001 12:00:00 AM"));
+            Assert.IsTrue(allProperties["AccessedDate"].Equals("1/1/0001 12:00:00 AM"));
+            Assert.IsTrue(allProperties["CreationDate"].Equals("1/1/0001 12:00:00 AM"));
+        }
     }
 }


### PR DESCRIPTION
Export:
Encloses every cell in double quotes in order to preserve all special characters in that cell.
If there are double quotes in a given cell, they get wrapped in double quotes.
For more info: https://hawq.apache.org/docs/userguide/2.3.0.0-incubating/datamgmt/load/g-escaping-in-csv-formatted-files.html

Import:
Uses CSVHelper (imported from NuGet) to parse a CSV file that is being imported.

TestCase:
Exports a CSV for a shellitem that contains special characters in the name field, and parses that file to check if all fields were read correctly into memory.

*Note: 
@yara-58, you should pull this branch and try exporting and then importing your ShellBags on the laptop you used when you found this bug, to further confirm that the bug is fixed.

Resolves #206 