### PR TITLE
No More Stacked Nodes

### DIFF
--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -178,6 +178,7 @@
     <Compile Include="ShellParser\ShellItems\ShellItem0x00.cs" />
     <Compile Include="ShellParser\ShellItems\SHITEM_UNKNOWNENTRY2.cs" />
     <Compile Include="UI\EventFilters\EventUserFilter.cs" />
+    <Compile Include="UI\Node\StackedNodes.cs" />
     <Compile Include="UI\Templates\CheckBoxWithLabel.xaml.cs">
       <DependentUpon>CheckBoxWithLabel.xaml</DependentUpon>
     </Compile>

--- a/WPF/SeeShells/SeeShells/UI/Node/StackedNodes.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/StackedNodes.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SeeShells.UI.Node
+{
+    public class StackedNodes : Button
+    {
+        public List<IEvent> events = new List<IEvent>();
+
+        public StackedNodes()
+        {
+            this.Width = 10;
+            this.Height = 10;
+            this.FontSize = 5;
+            this.FontWeight = FontWeights.Bold;
+        }
+
+        public void Add(IEvent aEvent)
+        {
+            events.Add(aEvent);
+        }
+    }
+}


### PR DESCRIPTION
Creates a new graphical object called `StackedNodes` that will be used to represent a cluster of nodes that have the same exact `EventTime`.
The `StackedNodes` object contains a list of all the events for the nodes that it combines into one and it extends Button in order to be a graphical object.
The `StackedNodes` is distinguishable from the rest of the nodes, by having a number that represents how many nodes it contains.
It does not have click functionality, as that will be added later by @bridCquinn.
![image](https://user-images.githubusercontent.com/42561260/76279999-f54ef480-6266-11ea-8ca0-7aab9e5fab0b.png)

Resolves #219 