### PR TITLE
Adds Proof of Concept Markdown rendering for WPF Help

### DIFF
--- a/WPF/SeeShells/README.md
+++ b/WPF/SeeShells/README.md
@@ -1,0 +1,12 @@
+# SeeShells
+SeeShells collects ShellBags specific Windows Registry keys and parses through them, and organizes the data found in them to display them on a graphical timeline. The graphical timeline is the unique feature that SeeShells offers over other existing parsers: this timeline makes ShellBag data easier to understand and facilitates the process of finding a significant pattern or piece of evidence.
+
+## Home page
+### How to Use
+
+#### Online Parsing
+TODO: Lorem Ipsum
+
+#### Offline Parsing
+TODO: Lorem Ipsum
+

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -51,6 +51,12 @@
     <Reference Include="KeraLua, Version=1.0.24.0, Culture=neutral, PublicKeyToken=6a194c04b9c89217, processorArchitecture=MSIL">
       <HintPath>..\packages\KeraLua.1.0.24\lib\net45\KeraLua.dll</HintPath>
     </Reference>
+    <Reference Include="Markdig, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.0.18.0\lib\net40\Markdig.dll</HintPath>
+    </Reference>
+    <Reference Include="Markdig.Wpf, Version=0.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.Wpf.0.3.1\lib\net452\Markdig.Wpf.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -254,6 +260,9 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\README.md">
+      <Link>resources\README.md</Link>
     </EmbeddedResource>
     <None Include="app.config" />
     <Content Include="NLog.config">

--- a/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml
@@ -4,12 +4,20 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:SeeShells.UI.Pages"
+      xmlns:wpf="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
       Title="HelpPage"
       Style="{StaticResource DefaultPageStyle}">
+    <FrameworkElement.CommandBindings>
+        <CommandBinding Command="{x:Static wpf:Commands.Hyperlink}" Executed="OpenHyperlink" />
+    </FrameworkElement.CommandBindings>
 
-    <Grid>
-        
+    <Grid Background="White">
+        <wpf:MarkdownViewer x:Name="HelpViewer" Markdown="[Configuration Reference](https://github.com/Kryptos-FR/markdig.wpf). ">
+            <wpf:MarkdownViewer.Resources>
+                <!-- To Customize Markdown Styling: https://github.com/Kryptos-FR/markdig.wpf/issues/31 -->
+            </wpf:MarkdownViewer.Resources>
+        </wpf:MarkdownViewer>
     </Grid>
 </Page>

--- a/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -12,6 +15,11 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using System.Xaml;
+using Markdig.Renderers;
+using Newtonsoft.Json;
+using SeeShells.IO.Networking.JSON;
+using XamlReader = System.Windows.Markup.XamlReader;
 
 namespace SeeShells.UI.Pages
 {
@@ -20,9 +28,40 @@ namespace SeeShells.UI.Pages
     /// </summary>
     public partial class HelpPage : Page
     {
+        private const string ReadmeFile = "README.md";
+
         public HelpPage()
         {
             InitializeComponent();
+            Loaded += OnLoad;
+        }
+
+        private void OnLoad(object sender, RoutedEventArgs e)
+        {
+
+            string markdown;
+
+            //todo use API call for getting help, if fails use internal resource.
+
+            //internal resource retrieval, see: https://stackoverflow.com/a/3314213
+            Assembly assembly = Assembly.GetExecutingAssembly();
+            string internalResourcePath = assembly.GetManifestResourceNames().Single(str => str.EndsWith(ReadmeFile));
+            using (Stream fileStream = assembly.GetManifestResourceStream(internalResourcePath))
+            {
+                using (StreamReader reader = new StreamReader(fileStream))
+                {
+                    markdown = reader.ReadToEnd();
+                }
+            }
+
+
+            HelpViewer.Markdown = markdown;
+        }
+
+        private void OpenHyperlink(object sender, ExecutedRoutedEventArgs e)
+        { 
+            Process.Start(e.Parameter.ToString());
+
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/packages.config
+++ b/WPF/SeeShells/SeeShells/packages.config
@@ -3,6 +3,8 @@
   <package id="CsvHelper" version="15.0.1" targetFramework="net46" />
   <package id="Extended.Wpf.Toolkit" version="3.8.1" targetFramework="net46" />
   <package id="KeraLua" version="1.0.24" targetFramework="net46" />
+  <package id="Markdig" version="0.18.0" targetFramework="net46" />
+  <package id="Markdig.Wpf" version="0.3.1" targetFramework="net46" />
   <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net46" />
   <package id="NLog" version="4.6.8" targetFramework="net46" />


### PR DESCRIPTION
- Adds Package and Window showing Markdown integration
- Adds basic Readme file to WPF
- Adds offline readme file skeleton

![image](https://user-images.githubusercontent.com/17878901/76731777-955bc080-6734-11ea-8efe-f89601fe065b.png)


*note* This merely is a proof of concept, new issues will have to be made for proper design choice of the help window, integration with API call, etc. 

Starts on #208, potentially resolves #207 