### PR TITLE
Adds Support for getting Help content from API

### DIFF
--- a/WPF/SeeShells/SeeShells/IO/Networking/JSON/HelpItem.cs
+++ b/WPF/SeeShells/SeeShells/IO/Networking/JSON/HelpItem.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace SeeShells.IO.Networking.JSON
+{
+    public class HelpItem
+    {
+        [JsonProperty("id", Required = Required.Always)]
+        public long Id { private get; set; }
+
+        [JsonProperty("title", Required = Required.Always)]
+        public string Title { private get; set; }
+
+        [JsonProperty("description", Required = Required.Always)]
+        public string Description { private get; set; }
+
+        public HelpItem()
+        {
+        }
+
+        public string GetHelpContent()
+        {
+            return Description;
+        }
+
+    }
+}

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -126,6 +126,7 @@
     <Compile Include="IO\Networking\APIException.cs" />
     <Compile Include="IO\Networking\JSON\APIError.cs" />
     <Compile Include="IO\Networking\JSON\GUIDPair.cs" />
+    <Compile Include="IO\Networking\JSON\HelpItem.cs" />
     <Compile Include="IO\Networking\JSON\RegistryLocations.cs" />
     <Compile Include="IO\Networking\JSON\ScriptPair.cs" />
     <Compile Include="ShellParser\Scripting\LuaShellItem.cs" />

--- a/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml
@@ -5,6 +5,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:SeeShells.UI.Pages"
       xmlns:wpf="clr-namespace:Markdig.Wpf;assembly=Markdig.Wpf"
+      xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
       Title="HelpPage"
@@ -14,7 +15,8 @@
     </FrameworkElement.CommandBindings>
 
     <Grid Background="White">
-        <wpf:MarkdownViewer x:Name="HelpViewer" Markdown="[Configuration Reference](https://github.com/Kryptos-FR/markdig.wpf). ">
+        <xctk:BusyIndicator x:Name="LoadingIndicator"  Grid.ZIndex="1"  IsBusy="True" BusyContent="Checking for Updates..."/>
+        <wpf:MarkdownViewer x:Name="HelpViewer" Markdown="# SeeShells Help" Margin="10">
             <wpf:MarkdownViewer.Resources>
                 <!-- To Customize Markdown Styling: https://github.com/Kryptos-FR/markdig.wpf/issues/31 -->
             </wpf:MarkdownViewer.Resources>

--- a/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml.cs
@@ -18,6 +18,7 @@ using System.Windows.Shapes;
 using System.Xaml;
 using Markdig.Renderers;
 using Newtonsoft.Json;
+using SeeShells.IO.Networking;
 using SeeShells.IO.Networking.JSON;
 using XamlReader = System.Windows.Markup.XamlReader;
 
@@ -28,7 +29,11 @@ namespace SeeShells.UI.Pages
     /// </summary>
     public partial class HelpPage : Page
     {
+
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
         private const string ReadmeFile = "README.md";
+        private static readonly string ReadmeLocation = Directory.GetCurrentDirectory() + '/' + ReadmeFile;
 
         public HelpPage()
         {
@@ -36,26 +41,65 @@ namespace SeeShells.UI.Pages
             Loaded += OnLoad;
         }
 
-        private void OnLoad(object sender, RoutedEventArgs e)
+        private async void OnLoad(object sender, RoutedEventArgs e)
         {
+            //use API call for getting help, if fails use internal resource.
+            string updatedHelpResult = string.Empty;
 
-            string markdown;
-
-            //todo use API call for getting help, if fails use internal resource.
-
-            //internal resource retrieval, see: https://stackoverflow.com/a/3314213
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            string internalResourcePath = assembly.GetManifestResourceNames().Single(str => str.EndsWith(ReadmeFile));
-            using (Stream fileStream = assembly.GetManifestResourceStream(internalResourcePath))
+            try
             {
-                using (StreamReader reader = new StreamReader(fileStream))
+                updatedHelpResult = await API.GetHelp();
+            }
+            catch (APIException ex)
+            {
+                logger.Error(ex);
+            }
+
+            string markdown = string.Empty;
+            try
+            {
+                markdown = File.ReadAllText(ReadmeLocation);
+            }
+            catch (IOException ex)
+            {
+                logger.Warn("Unable to Read cached Help file", ex);
+            }
+            
+            //check if the downloaded content has changed, if so save the file and use the updated help
+            
+            if ( updatedHelpResult != string.Empty && !updatedHelpResult.Equals(markdown, StringComparison.OrdinalIgnoreCase))
+            {
+                markdown = updatedHelpResult;
+
+                //update local file
+                try
                 {
-                    markdown = reader.ReadToEnd();
+                    File.WriteAllText(ReadmeLocation, markdown);
+                }
+                catch (IOException ex)
+                {
+                    logger.Error("Unable to save updated readme. Is the program in a write protected directory?", ex);
                 }
             }
 
+            // nothing cached, cant update, use default internal help.
+            if (markdown == string.Empty)
+            {
+
+                //internal resource retrieval, see: https://stackoverflow.com/a/3314213
+                Assembly assembly = Assembly.GetExecutingAssembly();
+                string internalResourcePath = assembly.GetManifestResourceNames().Single(str => str.EndsWith(ReadmeFile));
+                using (Stream fileStream = assembly.GetManifestResourceStream(internalResourcePath))
+                {
+                    using (StreamReader reader = new StreamReader(fileStream))
+                    {
+                        markdown = reader.ReadToEnd();
+                    }
+                }
+            }
 
             HelpViewer.Markdown = markdown;
+            LoadingIndicator.IsBusy = false;
         }
 
         private void OpenHyperlink(object sender, ExecutedRoutedEventArgs e)

--- a/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/HelpPage.xaml.cs
@@ -32,8 +32,8 @@ namespace SeeShells.UI.Pages
 
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-        private const string ReadmeFile = "README.md";
-        private static readonly string ReadmeLocation = Directory.GetCurrentDirectory() + '/' + ReadmeFile;
+        private const string HelpFile = "Help.md";
+        private static readonly string HelpFileLocation = Directory.GetCurrentDirectory() + '/' + HelpFile;
 
         public HelpPage()
         {
@@ -58,7 +58,7 @@ namespace SeeShells.UI.Pages
             string markdown = string.Empty;
             try
             {
-                markdown = File.ReadAllText(ReadmeLocation);
+                markdown = File.ReadAllText(HelpFileLocation);
             }
             catch (IOException ex)
             {
@@ -74,7 +74,7 @@ namespace SeeShells.UI.Pages
                 //update local file
                 try
                 {
-                    File.WriteAllText(ReadmeLocation, markdown);
+                    File.WriteAllText(HelpFileLocation, markdown);
                 }
                 catch (IOException ex)
                 {
@@ -88,7 +88,7 @@ namespace SeeShells.UI.Pages
 
                 //internal resource retrieval, see: https://stackoverflow.com/a/3314213
                 Assembly assembly = Assembly.GetExecutingAssembly();
-                string internalResourcePath = assembly.GetManifestResourceNames().Single(str => str.EndsWith(ReadmeFile));
+                string internalResourcePath = assembly.GetManifestResourceNames().Single(str => str.EndsWith(HelpFile));
                 using (Stream fileStream = assembly.GetManifestResourceStream(internalResourcePath))
                 {
                     using (StreamReader reader = new StreamReader(fileStream))

--- a/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
+++ b/WPF/SeeShells/SeeShellsTests/IO/Networking/APITests.cs
@@ -156,6 +156,50 @@ namespace SeeShellsTests.IO.Networking
 
         }
 
+        /// <summary>
+        /// Checks the functionality of the <see cref="API.GetHelp(string, IRestClient)"/> function
+        /// </summary>
+        [TestMethod()]
+        public void GetHelpTest()
+        {
+            string returnJSON = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleHelpResponse.json");
+            string serializedText = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleHelp.md");
+
+            using (new MockServer(TEST_PORT, API.HELP_ENDPOINT, (req, rsp, prm) => returnJSON))
+            {
+                var apiClient = new RestClient(TEST_URL);
+
+                var helpContent = API.GetHelp(apiClient).Result;
+
+                Assert.IsNotNull(apiClient);
+                Assert.AreEqual(serializedText, helpContent);
+            }
+
+        }
+        /// <summary>
+        /// Tests the exception throwing when <see cref="API.GetHelp(string, IRestClient)"/> fails.
+        /// </summary>
+        [TestMethod()]
+        public void GetHelp_ServerErrorTest()
+        {
+            string returnJSON = File.ReadAllText(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName + @"\TestResource\sampleAPIError.json");
+
+            using (new MockServer(TEST_PORT, API.HELP_ENDPOINT, (req, rsp, prm) => returnJSON))
+            {
+                var apiClient = new RestClient(TEST_URL);
+
+                try
+                {
+                    var helpResult = API.GetHelp(apiClient).Result;
+                    Assert.Fail("Expected Exception"); //expect exception
+                }
+                catch (AggregateException ex)
+                {
+                    Assert.AreEqual(new APIException("").GetType(), ex.InnerException.GetType());
+                }
+            }
+
+        }
 
     }
 }

--- a/WPF/SeeShells/SeeShellsTests/TestResource/sampleHelp.md
+++ b/WPF/SeeShells/SeeShellsTests/TestResource/sampleHelp.md
@@ -1,0 +1,1 @@
+# Help Description

--- a/WPF/SeeShells/SeeShellsTests/TestResource/sampleHelpResponse.json
+++ b/WPF/SeeShells/SeeShellsTests/TestResource/sampleHelpResponse.json
@@ -1,0 +1,1 @@
+{"success":1,"json":[{"id":1,"title":"Help!","description":"# Help Description"}]}


### PR DESCRIPTION
- Adds help content caching into current executable directory
- Refactored API slightly to decouple writing to FS & getting API data

![f3b72f58-e948-4047-a52e-be5267d57106](https://user-images.githubusercontent.com/17878901/77108716-1a76fc00-69f9-11ea-8dfd-400dbad6c065.gif)


Current testing within the current Help API specification, the markdown seems to work when we put just plain text into the database. Depending on how the website will want to render it, we might have to switch to encoding the help content itself (e.g. base64)

Resolves #231  