### PR TITLE
Position blocks horizontal

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
@@ -153,7 +153,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="*"/>
                                     </Grid.RowDefinitions>
-                                    <StackPanel x:Name="Blocks" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Bottom"/>
+                                    <StackPanel x:Name="Blocks" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,200,0"/>
                                     <StackPanel x:Name="Timelines" Grid.Row="1" Orientation="Horizontal"/>
                                     <StackPanel x:Name="TimeStamps" Grid.Row="1" Orientation="Horizontal" Margin="0,97,0,0"/>
                                     <StackPanel x:Name="TicksBar" Grid.Row="1" Orientation="Horizontal" Margin="0,43,0,0"/>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
@@ -153,7 +153,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="*"/>
                                     </Grid.RowDefinitions>
-                                    <StackPanel x:Name="Blocks" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,200,0"/>
+                                    <StackPanel x:Name="Blocks" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,450,0"/>
                                     <StackPanel x:Name="Timelines" Grid.Row="1" Orientation="Horizontal"/>
                                     <StackPanel x:Name="TimeStamps" Grid.Row="1" Orientation="Horizontal" Margin="0,97,0,0"/>
                                     <StackPanel x:Name="TicksBar" Grid.Row="1" Orientation="Horizontal" Margin="0,43,0,0"/>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -295,7 +295,6 @@ namespace SeeShells.UI.Pages
             AddTimeStamp(beginDate, endDate);
         }
 
-
         /// <summary>
         /// Creates a TimelinePanel
         /// </summary>
@@ -316,6 +315,12 @@ namespace SeeShells.UI.Pages
             return timelinePanel;
         }
 
+        /// <summary>
+        /// Creates a TimelinePanel for Blocks
+        /// </summary>
+        /// <param name="beginDate">begin date of timeline</param>
+        /// <param name="endDate">end date of timeline</param>
+        /// <returns>TimelinePanel that can space Blocks according to time</returns>
         private TimelinePanel MakeBlockPanel(DateTime beginDate, DateTime endDate)
         {
             TimelinePanel timelinePanel = new TimelinePanel

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -251,7 +251,7 @@ namespace SeeShells.UI.Pages
             DateTime endDate = beginDate.AddMinutes(1);
 
             TimelinePanel timelinePanel = MakeTimelinePanel(beginDate, endDate);
-            TimelinePanel blockPanel = MakeTimelinePanel(beginDate, endDate);
+            TimelinePanel blockPanel = MakeBlockPanel(beginDate, endDate);
 
             // Add all blocks onto a timeline
             foreach (Node.Node node in nodesCluster)
@@ -285,6 +285,7 @@ namespace SeeShells.UI.Pages
             }
 
             Timelines.Children.Add(timelinePanel);
+
             Blocks.Children.Add(blockPanel);
             Line separationLine = MakeTimelineSeparatingLine();
             Line blockSeperation = MakeBlockPanelSeparation();
@@ -307,6 +308,20 @@ namespace SeeShells.UI.Pages
             {
                 UnitTimeSpan = new TimeSpan(0, 0, 0, 1),
                 UnitSize = App.nodeCollection.nodeList[0].Width,
+                BeginDate = beginDate,
+                EndDate = endDate,
+                KeepOriginalOrderForOverlap = true
+            };
+
+            return timelinePanel;
+        }
+
+        private TimelinePanel MakeBlockPanel(DateTime beginDate, DateTime endDate)
+        {
+            TimelinePanel timelinePanel = new TimelinePanel
+            {
+                UnitTimeSpan = new TimeSpan(0, 0, 0, 10),
+                UnitSize = 200,
                 BeginDate = beginDate,
                 EndDate = endDate,
                 KeepOriginalOrderForOverlap = true
@@ -474,7 +489,7 @@ namespace SeeShells.UI.Pages
         {
             Line separatingSpace = new Line();
             separatingSpace.X1 = 0;
-            separatingSpace.X2 = 0;
+            separatingSpace.X2 = 1;
             separatingSpace.Y1 = 43;
             separatingSpace.Y2 = 150;
             separatingSpace.StrokeThickness = 2;


### PR DESCRIPTION
This fixes the horizontal alignment of the blocks with the nodes. 
![horizontal alignment](https://user-images.githubusercontent.com/27215280/77551382-aa4cf800-6e88-11ea-873a-ed5bf57aebe4.PNG)
This shows the last node on the timeline.
Resolves #242 