### PR TITLE
Access parent filter with right click on an even't block

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/EventFilters/EventParentFilter.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventFilters/EventParentFilter.cs
@@ -28,6 +28,11 @@ namespace SeeShells.UI.EventFilters
 
         public void Apply(ref List<Node.Node> nodes)
         {
+            if(shellItems.Length == 0)
+            {
+                return;
+            }
+
             for (int i = nodes.Count-1; i >= 0; i--)//iterate backwards because iterating forwards would be an issue with a list of changing size.
             {
                 Node.Node node = nodes[i];

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeParser.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeParser.cs
@@ -57,6 +57,14 @@ namespace SeeShells.UI.Node
             block.Text += aEvent.EventType + "\n";
             block.MouseEnter += Pages.TimelinePage.HoverBlock;
             block.MouseLeave += Pages.TimelinePage.HoverBlock;
+
+            ContextMenu contextMenu = new ContextMenu();
+            MenuItem parentFilter = new MenuItem();
+            parentFilter.Header = "Filter for events with same parent";
+            parentFilter.Click += Pages.TimelinePage.EventParentContextMenu_Click;
+            parentFilter.Tag = aEvent.Parent;
+            contextMenu.Items.Add(parentFilter);
+            block.ContextMenu = contextMenu;
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
@@ -93,8 +93,8 @@
                                             <!--TODO: This filter should be used if someone right clicks or something on an event. to "filter by parent"-->
                                             <StackPanel Orientation="Horizontal">
                                                 <DockPanel>
-                                                <TextBox x:Name="EventParentTextBox"  TextChanged="EventParentTextBox_TextChanged" HorizontalAlignment="Stretch" DockPanel.Dock="Left" Margin="5,0" IsEnabled="False" Width="289"/>
-                                            </DockPanel>
+                                                    <TextBox x:Name="EventParentTextBox" HorizontalAlignment="Stretch" DockPanel.Dock="Left" Margin="5,0" IsEnabled="False" Width="289"/>
+                                                </DockPanel>
                                             <Button x:Name="EventParentClearButton" Click="EventParentClearButton_Click">Clear</Button>
                                             </StackPanel>
                                         </StackPanel>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -28,10 +28,13 @@ namespace SeeShells.UI.Pages
 
         private TimeSpan maxRealTimeSpan = new TimeSpan(0, 0, 1, 0); // Max time in one timeline (1 min).
 
+        private static TimelinePage timelinePage;
+
         public TimelinePage()
         {
             InitializeComponent();
             BuildTimeline();
+            timelinePage = this;
         }
 
         private void AllStringFilter_TextChanged(object sender, TextChangedEventArgs e)
@@ -62,7 +65,7 @@ namespace SeeShells.UI.Pages
             endDatePicker.SelectedDate = null;
         }
 
-        private void UpdateFilter(string filterIdentifer, INodeFilter newFilter)
+        private static void UpdateFilter(string filterIdentifer, INodeFilter newFilter)
         {
             //remove the current filter that exists
             App.nodeCollection.RemoveEventFilter(filterIdentifer);
@@ -71,7 +74,7 @@ namespace SeeShells.UI.Pages
             App.nodeCollection.AddEventFilter(filterIdentifer, newFilter);
 
             //rebuild the timeline according to the new filters
-            this.RebuildTimeline();
+            timelinePage.RebuildTimeline();
         }
 
         /// <summary>
@@ -139,23 +142,24 @@ namespace SeeShells.UI.Pages
             EventUserFilter.SelectedItems.Clear();
         }
 
-        private void EventParentTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        public static void EventParentContextMenu_Click(object sender, RoutedEventArgs e)
         {
-            //TODO can only be implememented from a context menu option (e.g. right click) which allows us to get the actual event
-            TextBox emitter = (TextBox)sender;
+            MenuItem menuItem = sender as MenuItem;
+            IShellItem parent = (IShellItem)menuItem.Tag;
+            timelinePage.EventParentTextBox.Text = "Filtering by: " + parent.Name;
+            UpdateFilter(EVENT_PARENT_IDENTIFER, new EventParentFilter(parent));
+        }
+
+        private void EventParentClearButton_Click(object sender, RoutedEventArgs e)
+        {
             UpdateFilter(EVENT_PARENT_IDENTIFER, new EventParentFilter());
+            EventParentTextBox.Text = string.Empty;
         }
 
         private void RegexCheckBox_Click(object sender, RoutedEventArgs e)
         {
             //force fire a text changed event for the textbox so that the filter gets updated
             AllStringFilter_TextChanged(AllStringFilterTextBlock, new TextChangedEventArgs(e.RoutedEvent, UndoAction.None));
-        }
-
-        private void EventParentClearButton_Click(object sender, RoutedEventArgs e)
-        {
-            App.nodeCollection.RemoveEventFilter(EVENT_PARENT_IDENTIFER);
-            EventParentTextBox.Text = string.Empty;
         }
 
         private void EventNameFilter_TextChanged(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
Adds the ability to use the filter that filters events by an even't parent.
The filter is used through a right click context menu on an event's block and gives the option to filter the timeline by this event's parent.
After the filter is applied it is indicated by stating the name of the parent that the timeline was filtered by in the Event Parent Filter filter box on the left hand side of the UI.
The filter can then be cleared by pressing the clear button.

![image](https://user-images.githubusercontent.com/42561260/77597163-56680080-6ed4-11ea-97ec-55db2a1ade1c.png)

![image](https://user-images.githubusercontent.com/42561260/77597303-cd04fe00-6ed4-11ea-9eaa-179bb9544192.png)

Resolves #256 