### PR TITLE
Lua script modifications

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Scripting/ScriptHandler.cs
@@ -31,7 +31,7 @@ namespace SeeShells.ShellParser.Scripting
         {
             scripts.TryGetValue(identifier, out string script);
 
-            return new LuaShellItem(buf, script);
+            return new LuaShellItem(buf, identifier, script);
 
         }
     }


### PR DESCRIPTION
Resolves #255 
Resolves #253 

# Change Flow of Parsing
These changes can be seen in ShellItemList.cs
Instead of checking for the type class first, we look for an existing script. If the script exists, we use it to parse the shell item. If successful, the shell item is returned; otherwise, the code continues and checks if a type class exists for the shell item. If type is null, the shell item goes into the unknown bucket. Code should only rearranged/reorganized here instead of modified in any way.

# Broken Lua script Exceptions
These changes can be seen in LuaShellItem and ScriptHandler.
The identifier was added to the LuaShellItem constructor to make it easy to identify which scripts were breaking when logging an error message.
ParseShellItems was not having its exceptions be caught, and that seemed to be causing the crashing issue. Wrapping that in a try-catch let me set the skipParsing variable for invalid scripts, and it gave me a place to print the messages from the Exceptions I made inside the function.

When I ran through Klayton's steps to reproduce the bug, the program was no longer crashing. You can view the script error messages in the log.txt file:
![image](https://user-images.githubusercontent.com/38367751/77607585-3430ab80-6ef1-11ea-961e-d6b0e008b2d0.png)
