### PR TITLE
Adds additional Registry metadata from live/Online hives

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryHelper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryHelper.cs
@@ -9,6 +9,7 @@ namespace SeeShells.ShellParser.Registry
 {
     public static class RegistryHelper
     {
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
         public static DateTime? GetDateModified(RegistryHive registryHive, string path)
         {
             var lastModified = new FILETIME();
@@ -63,6 +64,7 @@ namespace SeeShells.ShellParser.Registry
             }
             catch (Exception ex)
             {
+                logger.Warn(ex, $"Couldn't retrieve registry modified date for {path}");
                 return null;
             }
         }

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
@@ -1,10 +1,22 @@
-﻿namespace SeeShells.ShellParser.Registry
+﻿
+using System;
+using Microsoft.Win32;
+using NLog;
+
+namespace SeeShells.ShellParser.Registry
 {
     public class RegistryKeyWrapper
     {
+
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
         public string RegistryUser { get; internal set; }
         public string RegistryPath { get; internal set; }
         public byte[] Value { get; }
+        public DateTime SlotModifiedDate { get; internal set; }
+        public DateTime LastRegistryWriteDate { get; internal set; }
+        public string ShellbagPath { get; internal set; }
+        public RegistryKeyWrapper Parent { get; }
 
         public RegistryKeyWrapper(byte[] value)
         {
@@ -19,5 +31,54 @@
             this.RegistryPath = registryPath;
         }
 
+        /// <summary>
+        /// Adapts a ShellBag RegistryKey to a common standard for retrieval of important information independent of key retrieval methodologies
+        /// </summary>
+        /// <param name="registryKey">A Registry Key associated with a Shellbag, retrieved via Win32 API </param>
+        /// <param name="keyValue">The Value of a Registry key containing Shellbag information. Found in the Parent of the registryKey being inspected</param>
+        /// <param name="parent">The parent of the currently inspected registryKey. Can be null.</param>
+        public RegistryKeyWrapper(Microsoft.Win32.RegistryKey registryKey, byte[] keyValue, RegistryKeyWrapper parent = null) : this(keyValue)
+        {
+            Parent = parent;
+            RegistryPath = registryKey.Name;
+            AdaptWin32Key(registryKey);
+        }
+
+        /// <summary>
+        /// Adapts a ShellBag RegistryKey to a common standard for retrieval of important information independent of key retrieval methodologies
+        /// </summary>
+        /// <param name="registryKey">A Registry Key associated with a Shellbag, retrieved from a offline registry reader API</param>
+        /// <param name="keyValue">The Value of a Registry key containing Shellbag information. Found in the Parent of the registryKey being inspected</param>
+        /// <param name="parent">The parent of the currently inspected registryKey. Can be null.</param>
+        public RegistryKeyWrapper(global::Registry.Abstractions.RegistryKey registryKey, byte[] keyValue, RegistryKeyWrapper parent = null) : this(keyValue)
+        {
+            //TODO adapt offline hive properties 
+        }
+
+        private void AdaptWin32Key(Microsoft.Win32.RegistryKey registryKey)
+        {
+
+            //obtain NodeSlot (Shellbag Path in registry)
+            SlotModifiedDate = DateTime.MinValue;
+            ShellbagPath = string.Empty;
+            try
+            {
+                int slot = (int)registryKey.GetValue("NodeSlot");
+                ShellbagPath = string.Format("{0}{1}\\{2}", registryKey.Name.Substring(0, registryKey.Name.IndexOf("BagMRU", StringComparison.Ordinal)), "Bags", slot);
+                
+                if (registryKey.Name.StartsWith("HKEY_USERS"))
+                {
+                    SlotModifiedDate = RegistryHelper.GetDateModified(RegistryHive.Users, ShellbagPath.Replace("HKEY_USERS\\", "")) ?? DateTime.MinValue;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Info(ex, $"NodeSlot was not found for registry key at {RegistryPath}");
+            }
+
+            //obtain the date the registry last wrote this key
+            LastRegistryWriteDate = RegistryHelper.GetDateModified(RegistryHive.Users, registryKey.Name.Replace("HKEY_USERS\\", "")) ?? DateTime.MinValue;
+
+        }
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
@@ -42,6 +42,12 @@ namespace SeeShells.ShellParser.Registry
                 baseDict.Add("RegistryOwner", RegKey.RegistryUser);
             if (RegKey.RegistryPath != string.Empty)
                 baseDict.Add("RegistryPath", RegKey.RegistryPath);
+            if (RegKey.ShellbagPath != string.Empty)
+                baseDict.Add("ShellbagPath", RegKey.ShellbagPath);
+            if (RegKey.LastRegistryWriteDate != DateTime.MinValue)
+                baseDict.Add("LastRegistryWriteDate", RegKey.LastRegistryWriteDate.ToString());
+            if (RegKey.SlotModifiedDate != DateTime.MinValue)
+                baseDict.Add("SlotModifiedDate", RegKey.SlotModifiedDate.ToString());
 
 
             return baseDict;

--- a/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
+++ b/WPF/SeeShells/SeeShellsTests/SeeShellsTests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Registry, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="RestSharp, Version=106.0.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.10.1\lib\net452\RestSharp.dll</HintPath>
     </Reference>


### PR DESCRIPTION
- Refactors RegistryKeyWrapper and key retrieval to support additional properties
- Adds additional logging for registry related processes

This PR is the beginning of retrieving additional information from the windows registry surrounding the Shellbag and their data (aka Registry metadata) The following Pieces of information are now included in all shellbags when using _**Online Parsing only**_
- Last Registry Write Date (the last time the registry key was interacted with for updating a shellbag as seen from it's parent)
- Shellbag Path (The path in the registry under BagsMRU) where the shellbag is hierarchically located
- SlotModified Date (the last time the registry key in the Shellbag path was updated)

Additional PR's and work is needed to enable this same information retrieval from Offline parsing

This PR is being made now to 
1. prevent a bigger change log for review at once
2. enable front end to handle the additional information
3. potentially distribute additional registry information retrieval work (offline parsing equivalent) 