### PR TITLE
Adds Absolute Path data to all ShellItems

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
@@ -41,10 +41,8 @@ namespace SeeShells.ShellParser.Registry
 
                 foreach (string location in Parser.GetRegistryLocations())
                 {
-                    foreach (RegistryKeyWrapper keyWrapper in IterateRegistry(userStore.OpenSubKey(location), location, null, ""))
+                    foreach (RegistryKeyWrapper keyWrapper in IterateRegistry(userStore.OpenSubKey(location), location, null))
                     {
-                        keyWrapper.RegistryUser = userStore.Name.Split('\\').Last(); //only pull the SID, dont include HKEY_USERS\
-
                         retList.Add(keyWrapper);
                     }
                 }
@@ -60,9 +58,8 @@ namespace SeeShells.ShellParser.Registry
         /// <param name="rk">The root registry key to start iterating over</param>
         /// <param name="subKey">the path of the first subkey under the root key</param>
         /// <param name="parent">The Parent Key of the Registry Key currently being iterated. Can be null</param>
-        /// <param name="path_prefix">the header to the current root key, needed for identification of the registry store</param>
         /// <returns></returns>
-        static List<RegistryKeyWrapper> IterateRegistry(RegistryKey rk, string subKey, RegistryKeyWrapper parent, string path_prefix)
+        static List<RegistryKeyWrapper> IterateRegistry(RegistryKey rk, string subKey, RegistryKeyWrapper parent)
         {
             List<RegistryKeyWrapper> retList = new List<RegistryKeyWrapper>();
             if (rk == null)
@@ -95,7 +92,6 @@ namespace SeeShells.ShellParser.Registry
                     continue;
                 }
 
-                string path = path_prefix;
                 RegistryKeyWrapper rkNextWrapper = null;
 
                 //shellbags only have their numerical identifer for the value name, not a shellbag otherwise
@@ -118,7 +114,7 @@ namespace SeeShells.ShellParser.Registry
                     }
                 }
 
-                retList.AddRange(IterateRegistry(rkNext, sk, rkNextWrapper, path));
+                retList.AddRange(IterateRegistry(rkNext, sk, rkNextWrapper));
             }
 
             return retList;

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
@@ -24,6 +24,8 @@ namespace SeeShells.ShellParser.Registry
             this.Value = value;
             RegistryUser = string.Empty;
             RegistryPath = string.Empty;
+            RegistrySID = string.Empty;
+            ShellbagPath = string.Empty;
         }
 
         public RegistryKeyWrapper(byte[] value, string registryUser, string registryPath) : this(value)

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
@@ -11,6 +11,7 @@ namespace SeeShells.ShellParser.Registry
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
         public string RegistryUser { get; internal set; }
+        public string RegistrySID { get; internal set; }
         public string RegistryPath { get; internal set; }
         public byte[] Value { get; }
         public DateTime SlotModifiedDate { get; internal set; }
@@ -57,6 +58,18 @@ namespace SeeShells.ShellParser.Registry
 
         private void AdaptWin32Key(Microsoft.Win32.RegistryKey registryKey)
         {
+            //obtain SID and Username(?)
+
+            //HKEY USERS registry is {hivename}\UserSID\....
+            string UserSID = registryKey.Name.Split('\\')[1];
+
+            // "_classes" is actually just a user's usrclass.dat, not a seperate user.
+            UserSID = UserSID.ToUpper().Replace("_CLASSES", "");
+            RegistrySID = UserSID;
+
+            //todo somehow retrieve usernames, this may need to be passed into this adapter.
+            //if we dont know the username, default to the SID. 
+            RegistryUser = RegistrySID;
 
             //obtain NodeSlot (Shellbag Path in registry)
             SlotModifiedDate = DateTime.MinValue;
@@ -73,7 +86,7 @@ namespace SeeShells.ShellParser.Registry
             }
             catch (Exception ex)
             {
-                logger.Info(ex, $"NodeSlot was not found for registry key at {RegistryPath}");
+                logger.Trace(ex, $"NodeSlot was not found for registry key at {RegistryPath}");
             }
 
             //obtain the date the registry last wrote this key

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
@@ -10,6 +10,7 @@ namespace SeeShells.ShellParser.Registry
     /// </summary>
     public class RegistryShellItemDecorator : IShellItem
     {
+        private const string AbsolutePathIdentifier = "AbsolutePath";
         protected IShellItem BaseShellItem { get; }
         protected RegistryKeyWrapper RegKey { get; }
 
@@ -17,12 +18,14 @@ namespace SeeShells.ShellParser.Registry
         /// Wraps a IShellItem with the relevant Registry Metadata from which it was produced.
         /// Adds registry related properties to the <seealso cref="IShellItem.GetAllProperties"/> method return
         /// </summary>
-        /// <param name="shellItem">The shellitem to be encapsulated. Cannot be null</param>
+        /// <param name="shellItem">The Shellitem to be encapsulated. Cannot be null</param>
         /// <param name="regKey">The Wrapper containing the information to be added to the <see cref="IShellItem"/> Can't be Null.</param>
-        public RegistryShellItemDecorator(IShellItem shellItem, RegistryKeyWrapper regKey)
+        /// <param name="parentShellItem">The Shellitem which when hierarchically organized, contains the Shellitem. Can be null </param>
+        public RegistryShellItemDecorator(IShellItem shellItem, RegistryKeyWrapper regKey, IShellItem parentShellItem = null)
         {
             BaseShellItem = shellItem ?? throw new ArgumentNullException(nameof(shellItem));
             RegKey = regKey ?? throw new ArgumentNullException(nameof(regKey));
+            AbsolutePath = SetAbsolutePath(parentShellItem);
         }
 
         public ushort Size => BaseShellItem.Size;
@@ -33,13 +36,21 @@ namespace SeeShells.ShellParser.Registry
         public DateTime AccessedDate => BaseShellItem.AccessedDate;
         public DateTime CreationDate => BaseShellItem.CreationDate;
 
+        //RegistryDecorator Specific properties
+        public string AbsolutePath { get; }
+
+
         public IDictionary<string, string> GetAllProperties()
         {
             IDictionary<string, string> baseDict = BaseShellItem.GetAllProperties();
             
+            baseDict.Add(AbsolutePathIdentifier, AbsolutePath);
+
             //add all registry key values
             if (RegKey.RegistryUser != string.Empty)
                 baseDict.Add("RegistryOwner", RegKey.RegistryUser);
+            if (RegKey.RegistryUser != string.Empty)
+                baseDict.Add("RegistrySID", RegKey.RegistrySID);
             if (RegKey.RegistryPath != string.Empty)
                 baseDict.Add("RegistryPath", RegKey.RegistryPath);
             if (RegKey.ShellbagPath != string.Empty)
@@ -51,6 +62,21 @@ namespace SeeShells.ShellParser.Registry
 
 
             return baseDict;
+        }
+
+        protected string SetAbsolutePath(IShellItem parentShellItem)
+        {
+            if (parentShellItem == null) 
+                return Name;
+            
+            IDictionary<string, string> parentProperties = parentShellItem.GetAllProperties();
+            if (parentProperties.TryGetValue(AbsolutePathIdentifier, out string parentPath))
+            {
+                //replace instances of \\\ because thats cascading, \\ can exist in network paths and \ is normal.
+                return $@"{parentPath}\{Name}".Replace("\\\\\\", "\\");
+            }
+
+            return Name;
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
@@ -30,8 +30,8 @@ namespace SeeShells.ShellParser.Registry
 
         public ushort Size => BaseShellItem.Size;
         public byte Type => BaseShellItem.Type;
-        public string TypeName => BaseShellItem.TypeName;
-        public string Name => BaseShellItem.Name;
+        public string TypeName => BaseShellItem.TypeName ?? string.Empty;
+        public string Name => BaseShellItem.Name ?? string.Empty;
         public DateTime ModifiedDate => BaseShellItem.ModifiedDate;
         public DateTime AccessedDate => BaseShellItem.AccessedDate;
         public DateTime CreationDate => BaseShellItem.CreationDate;
@@ -44,21 +44,21 @@ namespace SeeShells.ShellParser.Registry
         {
             IDictionary<string, string> baseDict = BaseShellItem.GetAllProperties();
             
-            baseDict.Add(AbsolutePathIdentifier, AbsolutePath);
+            baseDict[AbsolutePathIdentifier] = AbsolutePath;
 
             //add all registry key values
             if (RegKey.RegistryUser != string.Empty)
-                baseDict.Add("RegistryOwner", RegKey.RegistryUser);
+                baseDict["RegistryOwner"] =  RegKey.RegistryUser;
             if (RegKey.RegistryUser != string.Empty)
-                baseDict.Add("RegistrySID", RegKey.RegistrySID);
+                baseDict["RegistrySID"] = RegKey.RegistrySID;
             if (RegKey.RegistryPath != string.Empty)
-                baseDict.Add("RegistryPath", RegKey.RegistryPath);
+                baseDict["RegistryPath"] = RegKey.RegistryPath;
             if (RegKey.ShellbagPath != string.Empty)
-                baseDict.Add("ShellbagPath", RegKey.ShellbagPath);
+                baseDict["ShellbagPath"] = RegKey.ShellbagPath;
             if (RegKey.LastRegistryWriteDate != DateTime.MinValue)
-                baseDict.Add("LastRegistryWriteDate", RegKey.LastRegistryWriteDate.ToString());
+                baseDict["LastRegistryWriteDate"] = RegKey.LastRegistryWriteDate.ToString();
             if (RegKey.SlotModifiedDate != DateTime.MinValue)
-                baseDict.Add("SlotModifiedDate", RegKey.SlotModifiedDate.ToString());
+                baseDict["SlotModifiedDate"] = RegKey.SlotModifiedDate.ToString();
 
 
             return baseDict;

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
@@ -64,6 +64,12 @@ namespace SeeShells.ShellParser.Registry
             return baseDict;
         }
 
+        /// <summary>
+        /// Reconstructs the Absolute File Path to find the Item represented by this ShellItem, by obtaining the names of all parents <br/>
+        /// (i.e. "C:\Users\User\Desktop" when the ShellItem is the "Desktop" ShellItem Type)
+        /// </summary>
+        /// <param name="parentShellItem">The ShellItem which represents the hiearchical parent to the information in this ShellItem</param>
+        /// <returns>A filepath that should contain enough information to find the original item and related parent Shellbag items</returns>
         protected string SetAbsolutePath(IShellItem parentShellItem)
         {
             if (parentShellItem == null) 


### PR DESCRIPTION
- Slight refactoring to OnlineRegistryReader to shift responsibility of data
- Refactored ShellBagParser  to have RegistryKey to Shellbag relations known
- Refactored RegistryShellItemDecorator to make Parent-Aware ShellItems
- Added Registry SID (User account) Data to extracted registry info

As of writing, _**Online Parsing**_ correctly supplies Absolute Path values for output, _**Offline Parsing**_ does not. ( for the reasons mentioned in #271)