### PR TITLE
Possibe alignment modification

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Node/Node.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/Node.cs
@@ -15,6 +15,7 @@ namespace SeeShells.UI.Node
     {
         public IEvent aEvent;
         public InfoBlock block;
+        public TextBlock alignmentBlock { get; set; }
 
         /// <summary>
         /// The Node is an object that stores event data and has graphical objects to be displayed on a timeline.
@@ -27,6 +28,11 @@ namespace SeeShells.UI.Node
             this.block = block;
         }
 
+        public DateTime GetBlockTime()
+        {
+            return aEvent.EventTime;
+        }
+
         /// <summary>
         /// This is used to hide and show the block of information connected to each dot of information on the timeline.
         /// </summary>
@@ -34,10 +40,12 @@ namespace SeeShells.UI.Node
         {
             if (this.block.Visibility == Visibility.Collapsed)
             {
+                this.alignmentBlock.Visibility = Visibility.Hidden;
                 this.block.Visibility = Visibility.Visible;
             }
             else if (this.block.Visibility == Visibility.Visible)
             {
+                this.alignmentBlock.Visibility = Visibility.Collapsed;
                 this.block.Visibility = Visibility.Collapsed;
             }
         }

--- a/WPF/SeeShells/SeeShells/UI/Node/StackedNodes.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/StackedNodes.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -10,6 +11,7 @@ namespace SeeShells.UI.Node
         public List<IEvent> events = new List<IEvent>();
         public List<InfoBlock> blocks = new List<InfoBlock>();
         public List<Node> nodes = new List<Node>();
+        public TextBlock alignmentBlock { get; set; }
 
         public StackedNodes()
         {
@@ -17,6 +19,11 @@ namespace SeeShells.UI.Node
             this.Height = 20;
             this.FontSize = 10;
             this.FontWeight = FontWeights.Bold;
+        }
+
+        public DateTime GetBlockTime()
+        {
+            return events[0].EventTime;
         }
 
         public void ToggleBlock()
@@ -32,6 +39,11 @@ namespace SeeShells.UI.Node
                     block.Visibility = Visibility.Collapsed;
                 }
             }
+
+            if (alignmentBlock.Visibility == Visibility.Collapsed)
+                alignmentBlock.Visibility = Visibility.Hidden;
+            else
+                alignmentBlock.Visibility = Visibility.Collapsed;
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/UI/Node/StackedNodes.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/StackedNodes.cs
@@ -9,6 +9,7 @@ namespace SeeShells.UI.Node
     {
         public List<IEvent> events = new List<IEvent>();
         public List<InfoBlock> blocks = new List<InfoBlock>();
+        public List<Node> nodes = new List<Node>();
 
         public StackedNodes()
         {
@@ -16,11 +17,6 @@ namespace SeeShells.UI.Node
             this.Height = 20;
             this.FontSize = 10;
             this.FontWeight = FontWeights.Bold;
-        }
-
-        public void Add(IEvent aEvent)
-        {
-            events.Add(aEvent);
         }
 
         public void ToggleBlock()

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
@@ -147,7 +147,7 @@
                                 <Button x:Name="download" Content="Download" Click="DownloadClick"/>
                             </Viewbox>
                         </Grid>
-                        <ScrollViewer x:Name="TimelineScroll" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"  Margin="0,0,10.333,0" HorizontalAlignment="Right" Width="729" Height="402" VerticalAlignment="Top">
+                        <ScrollViewer x:Name="TimelineScroll" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"  Margin="0,0,10.333,0" HorizontalAlignment="Right" Width="729" Height="402" VerticalAlignment="Top" ScrollChanged="TimelineScroll_ScrollChanged">
                             <Grid x:Name="Timeline" Background="#292525" Width="Auto" Height="Auto">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto"/>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -193,7 +193,6 @@ namespace SeeShells.UI.Pages
                 }
 
                 List<Node.Node> nodeList = new List<Node.Node>();
-                List<TextBlock> blockList = new List<TextBlock>();
                 DateTime eventTime = App.nodeCollection.nodeList[0].aEvent.EventTime;
                 maxStackedNodes = 0;
                 int currentMaxStackedNodes = 0;
@@ -206,20 +205,16 @@ namespace SeeShells.UI.Pages
                     else
                     {
                         if(currentMaxStackedNodes > maxStackedNodes)
-                        {
                             maxStackedNodes = currentMaxStackedNodes;
-                        }
+
                         currentMaxStackedNodes = 1;
 
                         eventTime = node.aEvent.EventTime;
                     }
 
                     node.Style = (Style)Resources["Node"];
-                    if (node.Visibility == System.Windows.Visibility.Visible)
-                    {
+                    if (node.Visibility == Visibility.Visible)
                         nodeList.Add(node);
-                        blockList.Add(node.block);
-                    }
                     node.block.Visibility = Visibility.Collapsed;
 
                 }
@@ -262,7 +257,7 @@ namespace SeeShells.UI.Pages
                     AddTimeline(nodesCluster);
                 }
             }
-            catch (System.NullReferenceException ex)
+            catch (NullReferenceException ex)
             {
                 logger.Error(ex, "Null nodeList" + "\n" + ex.ToString());
                 return;

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -205,7 +205,7 @@ namespace SeeShells.UI.Pages
                         {
                             maxStackedNodes = currentMaxStackedNodes;
                         }
-                        currentMaxStackedNodes = 0;
+                        currentMaxStackedNodes = 1;
                         eventTime = node.aEvent.EventTime;
                     }
 
@@ -275,15 +275,6 @@ namespace SeeShells.UI.Pages
             TimelinePanel timelinePanel = MakeTimelinePanel(beginDate, endDate);
             TimelinePanel blockPanel = MakeBlockPanel(beginDate, endDate);
 
-            // Add all blocks onto a timeline
-            //foreach (Node.Node node in nodesCluster)
-            //{
-            //    node.IsChecked = false;
-            //    node.block.Style = (Style)Resources["TimelineBlock"];
-            //    TimelinePanel.SetDate(node.block, node.aEvent.EventTime);
-            //    blockPanel.Children.Add(node.block);
-            //}
-
             List<StackedNodes> stackedNodesList = GetStackedNodes(nodesCluster);
             // Add all nodes that stack onto a timeline
             foreach (StackedNodes stackedNode in stackedNodesList)
@@ -297,16 +288,16 @@ namespace SeeShells.UI.Pages
                 timelinePanel.Children.Add(stackedNode);
                 ConnectNodeToTimeline(timelinePanel, stackedNode.events[0].EventTime);
 
-                int invisibleBlocks = maxStackedNodes - stackedNode.blocks.Count;
-                while (invisibleBlocks != 0) // Adds invisible blocks as padding for a nice vertical allignment.
+                int invisibleBlocksNeeded = maxStackedNodes - stackedNode.blocks.Count;
+                if (invisibleBlocksNeeded != 0) // Adds invisible blocks as padding for a nice vertical allignment.
                 {
                     TextBlock invisibleBlock = new TextBlock();
                     invisibleBlock.Style = (Style)Resources["TimelineBlock"];
                     invisibleBlock.Visibility = Visibility.Visible;
-
+                    invisibleBlock.Height = invisibleBlocksNeeded * 70;
                     TimelinePanel.SetDate(invisibleBlock, stackedNode.events[0].EventTime);
                     blockPanel.Children.Add(invisibleBlock);
-                    invisibleBlocks--;
+                    invisibleBlocksNeeded--;
                 }
 
                 // Adds the actual node blocks
@@ -329,17 +320,13 @@ namespace SeeShells.UI.Pages
                 timelinePanel.Children.Add(node);
                 ConnectNodeToTimeline(timelinePanel, node.aEvent.EventTime);
 
-                int invisibleBlocks = maxStackedNodes -1;
-                while (invisibleBlocks != 0) // Adds invisible blocks as padding for a nice vertical allignment.
-                {
-                    TextBlock invisibleBlock = new TextBlock();
-                    invisibleBlock.Style = (Style)Resources["TimelineBlock"];
-                    invisibleBlock.Visibility = Visibility.Visible;
-
-                    TimelinePanel.SetDate(invisibleBlock, node.aEvent.EventTime);
-                    blockPanel.Children.Add(invisibleBlock);
-                    invisibleBlocks--;
-                }
+                // Adds invisible block as padding for a nice vertical allignment.
+                TextBlock invisibleBlock = new TextBlock();
+                invisibleBlock.Style = (Style)Resources["TimelineBlock"];
+                invisibleBlock.Visibility = Visibility.Visible;
+                invisibleBlock.Height = (maxStackedNodes - 1) * 70;
+                TimelinePanel.SetDate(invisibleBlock, node.aEvent.EventTime);
+                blockPanel.Children.Add(invisibleBlock);
 
                 // Adds the actual node blocks
                 node.IsChecked = false;

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -291,18 +291,16 @@ namespace SeeShells.UI.Pages
                 ConnectNodeToTimeline(timelinePanel, stackedNode.events[0].EventTime);
 
                 int numBlocksNeeded = maxStackedNodes - stackedNode.blocks.Count;
-                if (numBlocksNeeded != 0) // Adds invisible blocks as padding for a nice vertical allignment.
+                 // Adds invisible blocks as padding for a nice vertical allignment.
+                TextBlock alignmentBlock = new TextBlock
                 {
-                    TextBlock alignmentBlock = new TextBlock
-                    {
-                        Style = (Style)Resources["TimelineBlock"],
-                        Visibility = Visibility.Collapsed,
-                        Height = numBlocksNeeded * 70
-                    };
-                    stackedNode.alignmentBlock = alignmentBlock;
-                    TimelinePanel.SetDate(stackedNode.alignmentBlock, stackedNode.nodes[0].GetBlockTime());
-                    blockPanel.Children.Add(stackedNode.alignmentBlock);
-                }
+                    Style = (Style)Resources["TimelineBlock"],
+                    Visibility = Visibility.Collapsed,
+                    Height = numBlocksNeeded * 70
+                };
+                stackedNode.alignmentBlock = alignmentBlock;
+                TimelinePanel.SetDate(stackedNode.alignmentBlock, stackedNode.nodes[0].GetBlockTime());
+                blockPanel.Children.Add(stackedNode.alignmentBlock);
 
                 // Adds the actual node blocks
                 foreach (Node.Node node in stackedNode.nodes)
@@ -644,27 +642,34 @@ namespace SeeShells.UI.Pages
         /// </summary>
         public static void DotPress(object sender, EventArgs e)
         {
+            try
+            {
+                if (sender.GetType() == typeof(Node.Node))
+                {
+                    unToggleEventsThatAreTooClose(((Node.Node)sender).GetBlockTime());
+                    ((Node.Node)sender).ToggleBlock();
+
+                    if (toggledNodes.Contains((Node.Node)sender))
+                        toggledNodes.Remove((Node.Node)sender);
+                    else
+                        toggledNodes.Add((Node.Node)sender);
+                }
+                else if (sender.GetType() == typeof(StackedNodes))
+                {
+                    unToggleEventsThatAreTooClose(((StackedNodes)sender).GetBlockTime());
+                    ((StackedNodes)sender).ToggleBlock();
+
+                    if (toggledNodes.Contains((StackedNodes)sender))
+                        toggledNodes.Remove((StackedNodes)sender);
+                    else
+                        toggledNodes.Add((StackedNodes)sender);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, "Error with the toggled nodes.");
+            }
             
-            if(sender.GetType() == typeof(Node.Node))
-            {
-                unToggleEventsThatAreTooClose(((Node.Node)sender).GetBlockTime());
-                ((Node.Node)sender).ToggleBlock();
-
-                if (toggledNodes.Contains(sender))
-                    toggledNodes.Remove((Node.Node)sender);
-                else
-                    toggledNodes.Add((Node.Node)sender);
-            }
-            else if(sender.GetType() == typeof(StackedNodes))
-            {
-                unToggleEventsThatAreTooClose(((StackedNodes)sender).GetBlockTime());
-                ((StackedNodes)sender).ToggleBlock();
-
-                if (toggledNodes.Contains(sender))
-                    toggledNodes.Remove((StackedNodes)sender);
-                else
-                    toggledNodes.Add((StackedNodes)sender);
-            }
 
         }
 

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -724,6 +724,14 @@ namespace SeeShells.UI.Pages
         }
 
         /// <summary>
+        /// This pops up an information window when a block is clicked.
+        /// </summary>
+        public static void ClickBlock(object sender, EventArgs e)
+        {
+            ((InfoBlock)sender).PopOutInfo();
+        }
+
+        /// <summary>
         /// This is the Node version of this function to change the color of the blocks whose node is hovered over. 
         /// </summary>
         public void HoverNode(Object sender, EventArgs e)

--- a/WPF/SeeShells/SeeShells/UI/Windows/EventInformationWindow.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Windows/EventInformationWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:SeeShells.UI.Windows"
         mc:Ignorable="d"
         Deactivated="Window_Deactivated"
-        Title="Event Information" Height="250" Width="275">
+        Title="Event Information" Height="250" Width="320">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
@@ -14,10 +14,11 @@
         </Grid.RowDefinitions>
 
         <Viewbox Grid.Row="0" Stretch="Uniform">
-            <Label Grid.Row="0" FontWeight="Bold" Content="{Binding EventTitle}"/>
+            <Label FontWeight="Bold" Content="{Binding EventTitle}"/>
         </Viewbox>
-        <Viewbox Grid.Row="1" Stretch="Uniform" >
-            <Label Grid.Row="1" Content="{Binding EventBody}" />
-        </Viewbox>
+
+        <ScrollViewer Grid.Row="1">
+            <TextBlock FontSize="16px" Text="{Binding EventBody}" TextWrapping="Wrap" Margin="10" />
+        </ScrollViewer>
     </Grid>
 </Window>


### PR DESCRIPTION
I had an idea for resolving #244 but it failed; however, I made this modification while working through it.

Instead of making a bunch of hidden boxes, we can just make one per stack and make it the height of the needed boxes combined. This helps with the massive memory issue.

To avoid the awkward stacking issue when two nodes are close to each other, we can hide the stacks that conflict with the ones we want to open most recently (see the pictures). I think this works better for clicking around and viewing a bunch of events. This also solves the "jittering" problem Aleks and Bridget were talking about (I only understood what that issue was when working on this today).

With this PR, the events should always be visible when you click on them.

# Pictures
Click on the 6 node:
![image](https://user-images.githubusercontent.com/38367751/77837366-7c8cdb00-7136-11ea-83dd-4d6ba0113c5e.png)

Clicking on the 3 node:
![image](https://user-images.githubusercontent.com/38367751/77837372-8ca4ba80-7136-11ea-9164-f3ba9b14fd83.png)

As you can see, it hides the 6-node descriptions. When we click on the 6 node again, the 3 nodes hide and we can see the 6 ones.


If we don't like this idea, we can just close this PR without merging it.
If we like this idea, I think we can say it resolves #244 
(Parts of this code is also @AlekStoyanov 's; I worked off of what he started to make)
