### PR TITLE
Converts Registry obtained DateTimes into UTC

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
@@ -8,13 +8,26 @@ namespace SeeShells.ShellParser.Registry
     public class RegistryKeyWrapper
     {
 
-        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        private static Logger logger = LogManager.GetCurrentClassLogger();
 
         public string RegistryUser { get; internal set; }
         public string RegistryPath { get; internal set; }
         public byte[] Value { get; }
-        public DateTime SlotModifiedDate { get; internal set; }
-        public DateTime LastRegistryWriteDate { get; internal set; }
+
+        private DateTime slotModifiedDate = DateTime.MinValue;
+        public DateTime SlotModifiedDate
+        {
+            get => slotModifiedDate == DateTime.MinValue ? DateTime.MinValue : TimeZoneInfo.ConvertTimeToUtc(slotModifiedDate);
+            internal set => slotModifiedDate = value;
+        }
+
+        private DateTime lastRegistryWriteDate;
+        public DateTime LastRegistryWriteDate
+        {
+            get => lastRegistryWriteDate == DateTime.MinValue ? DateTime.MinValue : TimeZoneInfo.ConvertTimeToUtc(lastRegistryWriteDate);
+            internal set => lastRegistryWriteDate = value;
+        }
+
         public string ShellbagPath { get; internal set; }
         public RegistryKeyWrapper Parent { get; }
 


### PR DESCRIPTION
Partially Addressed #259 

It was discovered that DateTimes retrieved from the registry (that are not in shellbags) are in the Timezone of the machine instead of UTC like the shellbag data.

This is to prevent double conversions that can occur from future work in #259 

This PR makes it uniform UTC when retrieving any DateTime from an IShellItem