### PR TITLE
Timezone addition

### DIFF
--- a/WPF/SeeShells/SeeShells/IO/HtmlIO.cs
+++ b/WPF/SeeShells/SeeShells/IO/HtmlIO.cs
@@ -59,7 +59,7 @@ namespace SeeShells.IO
                         DateTime timeChange = Convert.ToDateTime(property.Value);
                         timeChange = TimeZoneInfo.ConvertTimeFromUtc(timeChange, time);
                         string timeFix = timeChange.ToString();
-                        outputFile.WriteLine("<p>" + property.Key + timeFix + "</p>");
+                        outputFile.WriteLine("<p>" + "["+property.Key +", "+ timeFix + "]"+ "</p>");
                     }
                     else
                     {

--- a/WPF/SeeShells/SeeShells/IO/HtmlIO.cs
+++ b/WPF/SeeShells/SeeShells/IO/HtmlIO.cs
@@ -53,7 +53,19 @@ namespace SeeShells.IO
                 outputFile.WriteLine("<div class=\"grid-item\" style=\"column-count: 3;\" > ");
                 foreach (KeyValuePair<string, string> property in node.aEvent.Parent.GetAllProperties())
                 {
-                    outputFile.WriteLine("<p>" + property + "</p>");
+                    TimeZoneInfo time = TimeZoneInfo.Local;
+                    if (property.Key.Contains("Date"))
+                    {
+                        DateTime timeChange = Convert.ToDateTime(property.Value);
+                        timeChange = TimeZoneInfo.ConvertTimeFromUtc(timeChange, time);
+                        string timeFix = timeChange.ToString();
+                        outputFile.WriteLine("<p>" + property.Key + timeFix + "</p>");
+                    }
+                    else
+                    {
+                        outputFile.WriteLine("<p>" + property + "</p>");
+
+                    }
                 }
 
                 outputFile.WriteLine("</div>");

--- a/WPF/SeeShells/SeeShells/IO/HtmlIO.cs
+++ b/WPF/SeeShells/SeeShells/IO/HtmlIO.cs
@@ -45,6 +45,7 @@ namespace SeeShells.IO
                 outputFile.WriteLine("<div class=\"grid-item\">");
                 outputFile.WriteLine("<h4><b>" + node.aEvent.Name + "</b></h4>");
                 outputFile.WriteLine("<p>" + node.aEvent.EventTime + "</p>");
+                outputFile.WriteLine("<p>" + node.aEvent.timeZone.StandardName + "</p>");
                 outputFile.WriteLine("<p>" + node.aEvent.EventType + "</p>");
                 outputFile.WriteLine("</div>");
                 

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
@@ -44,7 +44,6 @@ namespace SeeShells.ShellParser.Registry
         {
             IDictionary<string, string> baseDict = BaseShellItem.GetAllProperties();
             
-
             baseDict[AbsolutePathIdentifier] = AbsolutePath;
 
             //add all registry key values
@@ -65,14 +64,12 @@ namespace SeeShells.ShellParser.Registry
             return baseDict;
         }
 
-
         /// <summary>
         /// Reconstructs the Absolute File Path to find the Item represented by this ShellItem, by obtaining the names of all parents <br/>
         /// (i.e. "C:\Users\User\Desktop" when the ShellItem is the "Desktop" ShellItem Type)
         /// </summary>
         /// <param name="parentShellItem">The ShellItem which represents the hiearchical parent to the information in this ShellItem</param>
         /// <returns>A filepath that should contain enough information to find the original item and related parent Shellbag items</returns>
-
         protected string SetAbsolutePath(IShellItem parentShellItem)
         {
             if (parentShellItem == null) 

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryShellItemDecorator.cs
@@ -44,6 +44,7 @@ namespace SeeShells.ShellParser.Registry
         {
             IDictionary<string, string> baseDict = BaseShellItem.GetAllProperties();
             
+
             baseDict[AbsolutePathIdentifier] = AbsolutePath;
 
             //add all registry key values
@@ -64,12 +65,14 @@ namespace SeeShells.ShellParser.Registry
             return baseDict;
         }
 
+
         /// <summary>
         /// Reconstructs the Absolute File Path to find the Item represented by this ShellItem, by obtaining the names of all parents <br/>
         /// (i.e. "C:\Users\User\Desktop" when the ShellItem is the "Desktop" ShellItem Type)
         /// </summary>
         /// <param name="parentShellItem">The ShellItem which represents the hiearchical parent to the information in this ShellItem</param>
         /// <returns>A filepath that should contain enough information to find the original item and related parent Shellbag items</returns>
+
         protected string SetAbsolutePath(IShellItem parentShellItem)
         {
             if (parentShellItem == null) 

--- a/WPF/SeeShells/SeeShells/UI/Event.cs
+++ b/WPF/SeeShells/SeeShells/UI/Event.cs
@@ -9,7 +9,6 @@ namespace SeeShells.UI
 {
     public class Event : IEvent
     {
-        private TimeZone curTimeZone = TimeZone.CurrentTimeZone;
         /// <summary>
         /// Constructor for the Event class that takes in the parameters 
         /// listed below in order to create the elements of an event object. 
@@ -45,6 +44,7 @@ namespace SeeShells.UI
 
         public TimeZone timeZone { get
             {
+                TimeZone curTimeZone = TimeZone.CurrentTimeZone;
                 return curTimeZone;
             }
         }

--- a/WPF/SeeShells/SeeShells/UI/Event.cs
+++ b/WPF/SeeShells/SeeShells/UI/Event.cs
@@ -9,6 +9,7 @@ namespace SeeShells.UI
 {
     public class Event : IEvent
     {
+        private TimeZone curTimeZone = TimeZone.CurrentTimeZone;
         /// <summary>
         /// Constructor for the Event class that takes in the parameters 
         /// listed below in order to create the elements of an event object. 
@@ -41,5 +42,11 @@ namespace SeeShells.UI
         /// Categorizes the action which was preformed.
         /// </summary>
         public string EventType { get; set; }
+
+        public TimeZone timeZone { get
+            {
+                return curTimeZone;
+            }
+        }
     }
 }

--- a/WPF/SeeShells/SeeShells/UI/EventParser.cs
+++ b/WPF/SeeShells/SeeShells/UI/EventParser.cs
@@ -17,6 +17,7 @@ namespace SeeShells.UI
         public static List<IEvent> GetEvents(List<IShellItem> shells)
         {
             List<IEvent> eventList = new List<IEvent>();
+            TimeZoneInfo time = TimeZoneInfo.Local;
             foreach (IShellItem item in shells)
             {
                 IDictionary<String, String> parser = item.GetAllProperties();
@@ -26,6 +27,7 @@ namespace SeeShells.UI
                     {
                         String name = item.Name;
                         DateTime eventDate = Convert.ToDateTime(el.Value);
+                        eventDate = TimeZoneInfo.ConvertTimeFromUtc(eventDate, time);
                         String[] type = el.Key.Split('D');
                         Event e = new Event(name, eventDate, item, type[0]);
                         eventList.Add(e);

--- a/WPF/SeeShells/SeeShells/UI/IEvent.cs
+++ b/WPF/SeeShells/SeeShells/UI/IEvent.cs
@@ -33,5 +33,7 @@ namespace SeeShells.UI
         /// Categorizes the action which was preformed.
         /// </summary>
         string EventType { get; }
+
+        TimeZone timeZone { get; }
     }
 }

--- a/WPF/SeeShells/SeeShells/UI/Node/InfoBlock.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/InfoBlock.cs
@@ -39,8 +39,21 @@ namespace SeeShells.UI.Node
             
             foreach (KeyValuePair<string, string> property in this.aEvent.Parent.GetAllProperties())
             {
-                text += AddSpacesToCamelCase(property.Key) + ": " + property.Value;
-                text += "\n";
+                TimeZoneInfo time = TimeZoneInfo.Local;
+                if (property.Key.Contains("Date"))
+                {
+                    DateTime timeChange = Convert.ToDateTime(property.Value);
+                    timeChange = TimeZoneInfo.ConvertTimeFromUtc(timeChange, time);
+                    string timeFix = timeChange.ToString();
+                    text += AddSpacesToCamelCase(property.Key) + ": " + timeFix;
+                    text += "\n";
+                }
+                else
+                {
+                    text += AddSpacesToCamelCase(property.Key) + ": " + property.Value;
+                    text += "\n";
+
+                }
             };
 
             return text;

--- a/WPF/SeeShells/SeeShellsTests/UI/Mocks/MockEvent.cs
+++ b/WPF/SeeShells/SeeShellsTests/UI/Mocks/MockEvent.cs
@@ -26,5 +26,7 @@ namespace SeeShellsTests.UI.Mocks
         public IShellItem Parent { get; set; }
 
         public string EventType { get; set; }
+
+        public TimeZone timeZone { get; }
     }
 }


### PR DESCRIPTION
My solution to this bug was to convert all the datetimes from UTC to the Users local timezone on their system before they are added as part of an event. This was made possible by Klayton making all the registry DateTimes UTC, whereas before they were based on the user's computer while shellbags were based on Utc. I also added the Local Time Zone on the computer to the HTML output. I tested it using multiple timezones on my computer and the EventTimes change to that of the current timezone. 

<img width="855" alt="proofofoperation" src="https://user-images.githubusercontent.com/55147203/77850101-366b6200-719e-11ea-9659-9729b7569e81.PNG">

<img width="947" alt="current html output" src="https://user-images.githubusercontent.com/55147203/77850116-500ca980-719e-11ea-9da5-b2f218069525.PNG">

this closes issue #259