### PR TITLE
Prevents program crash when trying to write to a CSV file locked for editing

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -653,7 +653,8 @@ namespace SeeShells.UI.Pages
                         }
                         catch (IOException ex)
                         {
-                            System.Windows.MessageBox.Show("The file: \"" + name2 + "\" is being used by another process.");
+                            System.Windows.MessageBox.Show("The file: \"" + name2 + "\" is being used by another process.\n" +
+                                "Select a different file name or close the process to save the CSV.", "Cannot save file", MessageBoxButton.OK, MessageBoxImage.Exclamation);
                             logger.Info(ex, "The file: \"" + name2 + "\" is being used by another process.\n" + ex.ToString());
                             return;
                         }

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -5,6 +5,7 @@ using SeeShells.UI.EventFilters;
 using SeeShells.UI.Node;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -639,7 +640,26 @@ namespace SeeShells.UI.Pages
                 saveFileDialog2.ShowDialog();
                 string name2 = saveFileDialog2.FileName;
                 if (name2 != string.Empty)
+                {
+                    var file = new FileInfo(name2);
+                    if (file.Exists)
+                    {
+                        try // Check if the file is locked
+                        {
+                            using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None))
+                            {
+                                stream.Close();
+                            }
+                        }
+                        catch (IOException ex)
+                        {
+                            System.Windows.MessageBox.Show("The file: \"" + name2 + "\" is being used by another process.");
+                            logger.Info(ex, "The file: \"" + name2 + "\" is being used by another process.\n" + ex.ToString());
+                            return;
+                        }
+                    }
                     CsvIO.OutputCSVFile(App.ShellItems, name2);
+                }
             }
         }
 


### PR DESCRIPTION
If the user tries to export CSV output to an already existing CSV file that is currently opened by another process for editing, the program will notify the user with a message box, log the exception and proceed without exporting the CSV file.

![image](https://user-images.githubusercontent.com/42561260/77854072-f021fd00-71b5-11ea-967e-1a654fb6ae20.png)

Resolves #279 