### PR TITLE
Remaster gui

### DIFF
--- a/WPF/SeeShells/SeeShells/App.xaml
+++ b/WPF/SeeShells/SeeShells/App.xaml
@@ -44,7 +44,7 @@
                         <DockPanel Background="#FF343030">
                             <ToolBarTray IsLocked="True" Background="Transparent" DockPanel.Dock="Top">
                                 <ToolBar OverflowMode="Never" Loaded="Toolbar_Loaded" MinWidth="{Binding ActualWidth,
-                                    RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type WrapPanel}}}" Background="Transparent">
+                                    RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DockPanel}}}" Background="Transparent">
                                     <template:Switch/>
                                 </ToolBar>
                             </ToolBarTray>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
@@ -144,13 +144,18 @@
         </Grid>
 
         <Grid Grid.Row="1">
-            <ScrollViewer x:Name="TimelineScroll" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Right"  VerticalAlignment="Top" ScrollChanged="TimelineScroll_ScrollChanged" Margin="10, 10, 10, 10">
-                <Grid x:Name="Timeline" Background="#292525">
+            <ScrollViewer x:Name="TimelineScroll" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"  VerticalAlignment="Top" ScrollChanged="TimelineScroll_ScrollChanged" MinHeight="250" Margin="5,5,5,5" MinWidth="700">
+                <Grid x:Name="Timeline">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <StackPanel x:Name="Blocks" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,450,0"/>
+
+                    <Viewbox x:Name="EmptyTimeline" Margin="50,50,50,50" Grid.RowSpan="2" Visibility="Collapsed">
+                        <TextBlock TextWrapping="Wrap" Text="No Events to Show" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center" Margin="10,5,10,5" Width="65"></TextBlock>
+                    </Viewbox>
+                    
+                    <StackPanel x:Name="Blocks" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Bottom"/>
                     <StackPanel x:Name="Timelines" Grid.Row="1" Orientation="Horizontal"/>
                     <StackPanel x:Name="TimeStamps" Grid.Row="1" Orientation="Horizontal" Margin="0,97,0,0"/>
                     <StackPanel x:Name="TicksBar" Grid.Row="1" Orientation="Horizontal" Margin="0,43,0,0"/>
@@ -158,7 +163,7 @@
                 </Grid>
             </ScrollViewer>
         </Grid>
-
+        
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="3*"/>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -189,7 +189,6 @@ namespace SeeShells.UI.Pages
             {
                 if(App.nodeCollection.nodeList.Count == 0)
                 {
-                    System.Windows.MessageBox.Show("Hit");
                     logger.Info("No nodes to draw on the timeline.");
                     return;
                 }

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -189,6 +189,7 @@ namespace SeeShells.UI.Pages
             {
                 if(App.nodeCollection.nodeList.Count == 0)
                 {
+                    System.Windows.MessageBox.Show("Hit");
                     logger.Info("No nodes to draw on the timeline.");
                     return;
                 }
@@ -222,8 +223,13 @@ namespace SeeShells.UI.Pages
 
                 if (nodeList.Count == 0)
                 {
+                    EmptyTimeline.Visibility = Visibility.Visible;
                     logger.Info("All nodes are filtered out, no nodes to draw on the timeline.");
                     return;
+                }
+                else
+                {
+                    EmptyTimeline.Visibility = Visibility.Collapsed;
                 }
 
                 List<Node.Node> nodesCluster = new List<Node.Node>(); // Holds events for one timeline at a time.


### PR DESCRIPTION
Resolves #295 . The Timeline Panel was moving around the screen when it was being resized. That no longer happens. The background of the Timeline Grid has been changed to match the background of the application. In place of an empty screen when no nodes are showing, the words "No Events to Show" appear on the screen. I bug fix of changing an wrap to a dock panel happened. 