### PR TITLE
Adds Advanced Configuration conditional to invalid config warnings

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -366,6 +366,9 @@ namespace SeeShells.UI.Pages
 
         private bool ConfigurationFilesAreValid()
         {
+            if (AdvancedOptions.Visibility != Visibility.Visible)
+                return true;
+
             string messageBoxTitle = "Invalid configuration selected";
             string question = "The currently selected {0} file is invalid or missing.\n" +
                               "Would you like to proceed anyway?";


### PR DESCRIPTION
- No longer displays invalid configuration warnings if the advanced section is not visible
Resolves #257