### PR TITLE
Modifies the offline parser to retrieve additional time based registry metadata for shellitems

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/OfflineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/OfflineRegistryReader.cs
@@ -125,28 +125,6 @@ namespace SeeShells.ShellParser.Registry
                         logger.Warn("ACCESS DENIED: " + ex.Message);
                         continue;
                     }
-                /// The offline parser cannot GetValue() for any given gavlue, instead it has to get the data directly from a key value as it iterates over it
-                /// This code needs to be reworked
-/*                    int slot = 0;
-                    DateTime slotModified = DateTime.MinValue;
-                    string slotKeyName = "";
-                    try
-                    {
-                        slot = (int)rk.GetValue("NodeSlot");
-                        slotKeyName = string.Format("{0}{1}\\{2}", rk.Name.Substring(0, rk.Name.IndexOf("BagMRU")), "Bags", slot);
-                        if (rk.Name.StartsWith("HKEY_USERS"))
-                        {
-                            slotModified = RegistryHelper.GetDateModified(RegistryHive.Users, slotKeyName.Replace("HKEY_USERS\\", "")) ?? DateTime.MinValue;
-                        }
-                        else if (rkNext.Name.StartsWith("HKEY_CURRENT_USER"))
-                        {
-                            slotModified = RegistryHelper.GetDateModified(RegistryHive.CurrentUser, slotKeyName.Replace("HKEY_CURRENT_USER\\", "")) ?? DateTime.MinValue;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        //Console.WriteLine("NodeSlot was not found");
-                    }*/
 
                     string path = path_prefix;
                     RegistryKeyWrapper rkNextWrapper = null;
@@ -160,7 +138,7 @@ namespace SeeShells.ShellParser.Registry
                         foreach (KeyValue keyValue in k.Values)
                         {
                             byte[] byteVal = keyValue.ValueDataRaw;
-                            rkNextWrapper = new RegistryKeyWrapper(rkNext, byteVal, parent);
+                            rkNextWrapper = new RegistryKeyWrapper(rkNext, byteVal, hive, parent);
                             retList.Add(rkNextWrapper);
                         }
                         }

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/OfflineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/OfflineRegistryReader.cs
@@ -32,9 +32,8 @@ namespace SeeShells.ShellParser.Registry
             {
                 string userOfHive = FindOfflineUsername(hive);
 
-                foreach (byte[] keyValue in IterateRegistry(hive.GetKey(location), hive, location, 0, ""))
+                foreach (RegistryKeyWrapper keyWrapper in IterateRegistry(hive.GetKey(location), hive, location, null, ""))
                 {
-                    var keyWrapper = new RegistryKeyWrapper(keyValue);
                     if (userOfHive != string.Empty)
                     {
                         keyWrapper.RegistryUser = userOfHive;
@@ -99,9 +98,9 @@ namespace SeeShells.ShellParser.Registry
         /// <param name="indent"></param>
         /// <param name="path_prefix">the header to the current root key, needed for identification of the registry store</param>
         /// <returns></returns>
-        static List<byte[]> IterateRegistry(RegistryKey rk, RegistryHiveOnDemand hive, string subKey, int indent, string path_prefix)
+        static List<RegistryKeyWrapper> IterateRegistry(RegistryKey rk, RegistryHiveOnDemand hive, string subKey, RegistryKeyWrapper parent, string path_prefix)
             {
-                List<byte[]> retList = new List<byte[]>();
+                List<RegistryKeyWrapper> retList = new List<RegistryKeyWrapper>();
                 if (rk == null)
                 {
                     return retList;
@@ -149,9 +148,10 @@ namespace SeeShells.ShellParser.Registry
                         //Console.WriteLine("NodeSlot was not found");
                     }*/
 
-                    int intVal = 0;
                     string path = path_prefix;
-                    bool isNumeric = int.TryParse(valueName.KeyName, out intVal);
+                    RegistryKeyWrapper rkNextWrapper = null;
+
+                    bool isNumeric = int.TryParse(valueName.KeyName, out _);
                     if (isNumeric)
                     {
                         try
@@ -160,7 +160,8 @@ namespace SeeShells.ShellParser.Registry
                         foreach (KeyValue keyValue in k.Values)
                         {
                             byte[] byteVal = keyValue.ValueDataRaw;
-                            retList.Add(byteVal);
+                            rkNextWrapper = new RegistryKeyWrapper(rkNext, byteVal, parent);
+                            retList.Add(rkNextWrapper);
                         }
                         }
 
@@ -174,7 +175,7 @@ namespace SeeShells.ShellParser.Registry
                         }
                     }
 
-                    retList.AddRange(IterateRegistry(rkNext, hive, sk, indent + 2, path));
+                    retList.AddRange(IterateRegistry(rkNext, hive, sk, rkNextWrapper, path));
                 }
 
                 return retList;

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
@@ -142,7 +142,7 @@ namespace SeeShells.ShellParser.Registry
                     }
                 }
                 var shellbagKey = hive.GetKey(ShellbagPath);
-                SlotModifiedDate = shellbagKey.LastWriteTime.Value.DateTime;
+                SlotModifiedDate = shellbagKey.LastWriteTime.Value.LocalDateTime;
             }
             catch (Exception ex)
             {
@@ -150,8 +150,7 @@ namespace SeeShells.ShellParser.Registry
             }
 
             //obtain the date the registry last wrote this key
-            LastRegistryWriteDate = registryKey.LastWriteTime.Value.DateTime;
-
+            LastRegistryWriteDate = registryKey.LastWriteTime.Value.LocalDateTime;
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
@@ -68,7 +68,9 @@ namespace SeeShells.ShellParser.Registry
         /// <param name="parent">The parent of the currently inspected registryKey. Can be null.</param>
         public RegistryKeyWrapper(global::Registry.Abstractions.RegistryKey registryKey, byte[] keyValue, RegistryKeyWrapper parent = null) : this(keyValue)
         {
-            //TODO adapt offline hive properties 
+            Parent = parent;
+            RegistryPath = registryKey.KeyName;
+            AdaptOfflineKey(registryKey);
         }
 
         private void AdaptWin32Key(Microsoft.Win32.RegistryKey registryKey)
@@ -106,6 +108,48 @@ namespace SeeShells.ShellParser.Registry
 
             //obtain the date the registry last wrote this key
             LastRegistryWriteDate = RegistryHelper.GetDateModified(RegistryHive.Users, registryKey.Name.Replace("HKEY_USERS\\", "")) ?? DateTime.MinValue;
+
+        }
+
+        private void AdaptOfflineKey(global::Registry.Abstractions.RegistryKey registryKey)
+        {
+            //obtain SID and Username(?)
+
+            //HKEY USERS registry is UserSID\....
+            string UserSID = registryKey.KeyPath.Split('\\')[0];
+
+            // "_classes" is actually just a user's usrclass.dat, not a seperate user.
+            UserSID = UserSID.ToUpper().Replace("_CLASSES", "");
+            RegistrySID = UserSID;
+
+            //todo somehow retrieve usernames, this may need to be passed into this adapter.
+            //if we dont know the username, default to the SID. 
+            RegistryUser = RegistrySID;
+
+            //obtain NodeSlot (Shellbag Path in registry)
+            SlotModifiedDate = DateTime.MinValue;
+            LastRegistryWriteDate = DateTime.MinValue;
+            ShellbagPath = string.Empty;
+            try
+            {
+                var values = registryKey.Values;
+                foreach(global::Registry.Abstractions.KeyValue kv in registryKey.Values)
+                {
+                    if(kv.ValueName.Equals("NodeSlot"))
+                    {
+                        string slot = kv.ValueData;
+                        ShellbagPath = string.Format("{0}{1}\\{2}", registryKey.KeyPath.Substring(0, registryKey.KeyPath.IndexOf("BagMRU", StringComparison.Ordinal)), "Bags", slot);
+                    }
+                }
+                SlotModifiedDate = registryKey.LastWriteTime.Value.DateTime;
+            }
+            catch (Exception ex)
+            {
+                logger.Trace(ex, $"NodeSlot was not found for registry key at {RegistryPath}");
+            }
+
+            //obtain the date the registry last wrote this key
+            LastRegistryWriteDate = registryKey.LastWriteTime.Value.DateTime;
 
         }
     }

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/RegistryKeyWrapper.cs
@@ -66,11 +66,11 @@ namespace SeeShells.ShellParser.Registry
         /// <param name="registryKey">A Registry Key associated with a Shellbag, retrieved from a offline registry reader API</param>
         /// <param name="keyValue">The Value of a Registry key containing Shellbag information. Found in the Parent of the registryKey being inspected</param>
         /// <param name="parent">The parent of the currently inspected registryKey. Can be null.</param>
-        public RegistryKeyWrapper(global::Registry.Abstractions.RegistryKey registryKey, byte[] keyValue, RegistryKeyWrapper parent = null) : this(keyValue)
+        public RegistryKeyWrapper(global::Registry.Abstractions.RegistryKey registryKey, byte[] keyValue, global::Registry.RegistryHiveOnDemand hive, RegistryKeyWrapper parent = null) : this(keyValue)
         {
             Parent = parent;
             RegistryPath = registryKey.KeyName;
-            AdaptOfflineKey(registryKey);
+            AdaptOfflineKey(registryKey, hive);
         }
 
         private void AdaptWin32Key(Microsoft.Win32.RegistryKey registryKey)
@@ -111,7 +111,7 @@ namespace SeeShells.ShellParser.Registry
 
         }
 
-        private void AdaptOfflineKey(global::Registry.Abstractions.RegistryKey registryKey)
+        private void AdaptOfflineKey(global::Registry.Abstractions.RegistryKey registryKey, global::Registry.RegistryHiveOnDemand hive)
         {
             //obtain SID and Username(?)
 
@@ -141,7 +141,8 @@ namespace SeeShells.ShellParser.Registry
                         ShellbagPath = string.Format("{0}{1}\\{2}", registryKey.KeyPath.Substring(0, registryKey.KeyPath.IndexOf("BagMRU", StringComparison.Ordinal)), "Bags", slot);
                     }
                 }
-                SlotModifiedDate = registryKey.LastWriteTime.Value.DateTime;
+                var shellbagKey = hive.GetKey(ShellbagPath);
+                SlotModifiedDate = shellbagKey.LastWriteTime.Value.DateTime;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The new modifications to the offline parser make it build registry key wrappers while parsing and enable it to gather time based registry metadata for shellitems such as:
- SlotModifiedDate
- LastRegistryWriteDate
- ShellbagPath
- Parent

Resolves: #281 