### PR TITLE
Fix End Date Filter UI not being inclusive of the date

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -61,7 +61,10 @@ namespace SeeShells.UI.Pages
 
         private void UpdateDateFilter(object sender, SelectionChangedEventArgs e)
         {
-            UpdateFilter("DateFilter", new DateRangeFilter(startDatePicker.SelectedDate, endDatePicker.SelectedDate));
+            //set the end date's time to the end of the day
+            DateTime? endTime = endDatePicker.SelectedDate?.AddHours(23).AddMinutes(59).AddSeconds(59) ??
+                                endDatePicker.SelectedDate;
+            UpdateFilter("DateFilter", new DateRangeFilter(startDatePicker.SelectedDate, endTime));
 
         }
 


### PR DESCRIPTION
- Fixes bug where the End Date option on the UI was not inclusive of it's day as per the documentation for the EndDateFilter

Steps to reproduce error (before this PR)
1. Use Seeshells to view a timeline with at least one date
2. Set the start date and end date in the Event Date Filter to the same date
3. Observe no timeline is displayed. 