### PR TITLE
Adds single node navigation capability

### DIFF
--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -192,6 +192,7 @@
     <Compile Include="ShellParser\ShellItems\SHITEM_UNKNOWNENTRY2.cs" />
     <Compile Include="UI\EventFilters\EventUserFilter.cs" />
     <Compile Include="UI\Node\InfoBlock.cs" />
+    <Compile Include="UI\Node\NodeNavigation.cs" />
     <Compile Include="UI\Node\StackedNodes.cs" />
     <Compile Include="UI\Windows\AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeNavigation.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeNavigation.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+using SeeShells.UI.Pages;
+
+namespace SeeShells.UI.Node
+{
+    /// <summary>
+    /// Used to navigate trough nodes one by one
+    /// </summary>
+    public class NodeNavigation
+    {
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+        ResourceDictionary resourceDictionary = new ResourceDictionary();
+        List<Object> nodes;
+        Object currNode;
+        int currIndex;
+
+        public NodeNavigation(List<Object> nodes)
+        {
+            resourceDictionary.Source = new Uri("pack://application:,,,/SeeShells;component/UI/Templates/NodeStyle.xaml");
+            this.nodes = nodes;
+            SortNodes();
+            currIndex = 0;
+        }
+
+        /// <summary>
+        /// Navigates to the next node further in time.
+        /// </summary>
+        public void GoToNextNode()
+        {
+            currIndex++;
+            if (nodes.ElementAtOrDefault(currIndex) != null)
+            {
+                if(nodes[currIndex] is Node)
+                {
+                    ResetPrevNodeStyle();
+                    currNode = (Node)nodes[currIndex];
+                    (currNode as Node).BringIntoView();
+                    (currNode as Node).Style = (Style)resourceDictionary["LitUpNode"];
+
+                }
+                else if (nodes[currIndex] is StackedNodes)
+                {
+                    ResetPrevNodeStyle();
+                    currNode = (StackedNodes)nodes[currIndex];
+                    (currNode as StackedNodes).BringIntoView();
+                    (currNode as StackedNodes).Style = (Style)resourceDictionary["LitUpStackedNode"];
+                }
+            }
+            else
+            {
+                currIndex--;
+            }
+
+        }
+
+        /// <summary>
+        /// Navigates to the next node beack in time.
+        /// </summary
+        public void GoToPreviousNode()
+        {
+            currIndex--;
+            if (nodes.ElementAtOrDefault(currIndex) != null)
+            {
+                if (nodes[currIndex] is Node)
+                {
+                    ResetPrevNodeStyle();
+                    currNode = (Node)nodes[currIndex];
+                    (currNode as Node).BringIntoView();
+                    (currNode as Node).Style = (Style)resourceDictionary["LitUpNode"];
+
+                }
+                else if (nodes[currIndex] is StackedNodes)
+                {
+                    ResetPrevNodeStyle();
+                    currNode = (StackedNodes)nodes[currIndex];
+                    (currNode as StackedNodes).BringIntoView();
+                    (currNode as StackedNodes).Style = (Style)resourceDictionary["LitUpStackedNode"];
+                }
+            }
+            else
+            {
+                currIndex++;
+            }
+        }
+
+        /// <summary>
+        /// Used to set a new starting point from where to navigate nodes one by one.
+        /// </summary>
+        /// <param name="node">the node that a user clicks from the timeline to become the begining node for navigation</param>
+        public void SetNewStartingPoint(Object node)
+        {
+            currIndex = nodes.IndexOf(node);
+        }
+
+        /// <summary>
+        /// Changes the style of the node that last visited trough navigation back to default.
+        /// </summary>
+        private void ResetPrevNodeStyle()
+        {
+            if(currNode != null)
+            {
+                if(currNode is Node)
+                {
+                    (currNode as Node).Style = (Style)resourceDictionary["Node"];
+                }
+                else if(currNode is StackedNodes)
+                {
+                    (currNode as StackedNodes).Style = (Style)resourceDictionary["StackedNode"];
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sorts the nodes based on the time the event occures. This is done because there are ordering issues if the nodes are parsed directly from the childern of UI elements that contain them.
+        /// </summary>
+        private void SortNodes()
+        {
+            Comparison<Object> nodesComparer = new Comparison<Object>(CompareNodes);
+            nodes.Sort(nodesComparer);
+        }
+
+        /// <summary>
+        /// Compares nodes by their event time fields, reguardless of the node type.
+        /// </summary>
+        /// <param name="x">First node for camparison</param>
+        /// <param name="y">Second node for comparison</param>
+        /// <returns></returns>
+        private static int CompareNodes(Object x, Object y)
+        {
+            if(x is Node && y is Node)
+            {
+                if (DateTime.Compare((x as Node).GetBlockTime(), (y as Node).GetBlockTime()) < 0)
+                {
+                    return -1;
+                }
+                else if (DateTime.Compare((x as Node).GetBlockTime(), (y as Node).GetBlockTime()) > 0)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+            else if(x is Node && y is StackedNodes)
+            {
+                if (DateTime.Compare((x as Node).GetBlockTime(), (y as StackedNodes).GetBlockTime()) < 0)
+                {
+                    return -1;
+                }
+                else if (DateTime.Compare((x as Node).GetBlockTime(), (y as StackedNodes).GetBlockTime()) > 0)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+            else if(x is StackedNodes && y is StackedNodes)
+            {
+                if (DateTime.Compare((x as StackedNodes).GetBlockTime(), (y as StackedNodes).GetBlockTime()) < 0)
+                {
+                    return -1;
+                }
+                else if (DateTime.Compare((x as StackedNodes).GetBlockTime(), (y as StackedNodes).GetBlockTime()) > 0)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+            else if(x is StackedNodes && y is Node)
+            {
+                if (DateTime.Compare((x as StackedNodes).GetBlockTime(), (y as Node).GetBlockTime()) < 0)
+                {
+                    return -1;
+                }
+                else if (DateTime.Compare((x as StackedNodes).GetBlockTime(), (y as Node).GetBlockTime()) > 0)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+
+            logger.Warn("Sorting the nodes for navigation failed!");
+            return 0;
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeNavigation.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeNavigation.cs
@@ -58,7 +58,7 @@ namespace SeeShells.UI.Node
 
         /// <summary>
         /// Navigates to the next node back in time.
-        /// </summary
+        /// </summary>
         public void GoToPreviousNode()
         {
             currIndex--;

--- a/WPF/SeeShells/SeeShells/UI/Node/NodeNavigation.cs
+++ b/WPF/SeeShells/SeeShells/UI/Node/NodeNavigation.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Media;
-using SeeShells.UI.Pages;
 
 namespace SeeShells.UI.Node
 {
     /// <summary>
-    /// Used to navigate trough nodes one by one
+    /// Used to navigate through nodes one by one.
     /// </summary>
     public class NodeNavigation
     {
@@ -61,7 +57,7 @@ namespace SeeShells.UI.Node
         }
 
         /// <summary>
-        /// Navigates to the next node beack in time.
+        /// Navigates to the next node back in time.
         /// </summary
         public void GoToPreviousNode()
         {
@@ -93,14 +89,14 @@ namespace SeeShells.UI.Node
         /// <summary>
         /// Used to set a new starting point from where to navigate nodes one by one.
         /// </summary>
-        /// <param name="node">the node that a user clicks from the timeline to become the begining node for navigation</param>
+        /// <param name="node">the node that a user clicks from the timeline to become the beginning node for navigation </param>
         public void SetNewStartingPoint(Object node)
         {
             currIndex = nodes.IndexOf(node);
         }
 
         /// <summary>
-        /// Changes the style of the node that last visited trough navigation back to default.
+        /// Changes the style of the node that was last visited through navigation back to default.
         /// </summary>
         private void ResetPrevNodeStyle()
         {
@@ -118,7 +114,7 @@ namespace SeeShells.UI.Node
         }
 
         /// <summary>
-        /// Sorts the nodes based on the time the event occures. This is done because there are ordering issues if the nodes are parsed directly from the childern of UI elements that contain them.
+        /// Sorts the nodes based on the time the event occurs. This is done because there are ordering issues if the nodes are parsed directly from the children of UI elements that contain them.
         /// </summary>
         private void SortNodes()
         {
@@ -127,9 +123,9 @@ namespace SeeShells.UI.Node
         }
 
         /// <summary>
-        /// Compares nodes by their event time fields, reguardless of the node type.
+        /// Compares nodes by their event time fields, regardless of the node type.
         /// </summary>
-        /// <param name="x">First node for camparison</param>
+        /// <param name="x">First node for comparison</param>
         /// <param name="y">Second node for comparison</param>
         /// <returns></returns>
         private static int CompareNodes(Object x, Object y)

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml
@@ -154,7 +154,7 @@
                     <Viewbox x:Name="EmptyTimeline" Margin="50,50,50,50" Grid.RowSpan="2" Visibility="Collapsed">
                         <TextBlock TextWrapping="Wrap" Text="No Events to Show" Foreground="White" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center" Margin="10,5,10,5" Width="65"></TextBlock>
                     </Viewbox>
-                    
+
                     <StackPanel x:Name="Blocks" Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Bottom" Margin="0,0,350,0"/>
                     <StackPanel x:Name="Timelines" Grid.Row="1" Orientation="Horizontal"/>
                     <StackPanel x:Name="TimeStamps" Grid.Row="1" Orientation="Horizontal" Margin="0,97,0,0"/>
@@ -166,9 +166,11 @@
         
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="3*"/>
-                <ColumnDefinition Width="3*"/>
                 <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="0.2*"/>
+                <ColumnDefinition Width="0.2*"/>
             </Grid.ColumnDefinitions>
 
             <Viewbox Grid.Column="0" Margin="5,5,5,0">
@@ -179,6 +181,12 @@
             </Viewbox>
             <Viewbox Grid.Column="2" Margin="5,5,5,5">
                 <Button x:Name="download" Content="Download" Click="DownloadClick"/>
+            </Viewbox>
+            <Viewbox Grid.Column="3">
+                <Button x:Name="prevNode"  FontFamily="Marlett" FontSize="50"  Content="3" Click="PrevNode_Click"/>
+            </Viewbox>
+            <Viewbox Grid.Column="4">
+                <Button x:Name="nextNode"  FontFamily="Marlett" Content="4" FontSize="50" Click="NextNode_Click"/>
             </Viewbox>
         </Grid>
     </Grid>

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Shapes;
 using Xceed.Wpf.Toolkit;
 using Xceed.Wpf.Toolkit.Primitives;
 using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 
 namespace SeeShells.UI.Pages
 {
@@ -32,6 +33,8 @@ namespace SeeShells.UI.Pages
         private TimeSpan maxRealTimeSpan = new TimeSpan(0, 0, 1, 0); // Max time in one timeline (1 min).
 
         private static TimelinePage timelinePage;
+        private static NodeNavigation nodeNavigation;
+        private static List<Object> allNodes;
 
         private static List<ToggleButton> toggledNodes = new List<ToggleButton>();
         private Boolean AutoScroll = true;
@@ -183,6 +186,16 @@ namespace SeeShells.UI.Pages
             EventNameFilter.Clear();
         }
 
+        private void NextNode_Click(object sender, RoutedEventArgs e)
+        {
+            nodeNavigation.GoToNextNode();
+        }
+
+        private void PrevNode_Click(object sender, RoutedEventArgs e)
+        {
+            nodeNavigation.GoToPreviousNode();
+        }
+
         /// <summary>
         /// Builds a timeline dynamically. Creates one timeline for each cluster of events.
         /// </summary>
@@ -234,6 +247,7 @@ namespace SeeShells.UI.Pages
                     EmptyTimeline.Visibility = Visibility.Collapsed;
                 }
 
+                allNodes = new List<Object>();
                 List<Node.Node> nodesCluster = new List<Node.Node>(); // Holds events for one timeline at a time.
                 nodesCluster.Add(nodeList[0]);
                 DateTime previousDate = nodeList[0].aEvent.EventTime;
@@ -265,6 +279,7 @@ namespace SeeShells.UI.Pages
                 {
                     AddTimeline(nodesCluster);
                 }
+                InitializeNodeNavigation();
             }
             catch (NullReferenceException ex)
             {
@@ -296,6 +311,7 @@ namespace SeeShells.UI.Pages
                 stackedNode.Style = (Style)Resources["StackedNode"];
                 TimelinePanel.SetDate(stackedNode, stackedNode.events[0].EventTime);
                 stackedNode.Content = stackedNode.events.Count.ToString();
+                allNodes.Add(stackedNode);
                 timelinePanel.Children.Add(stackedNode);
                 ConnectNodeToTimeline(timelinePanel, stackedNode.events[0].EventTime);
 
@@ -342,6 +358,7 @@ namespace SeeShells.UI.Pages
                 node.MouseEnter += HoverNode;
                 node.MouseLeave += HoverNode;
                 TimelinePanel.SetDate(node, node.aEvent.EventTime);
+                allNodes.Add(node);
                 timelinePanel.Children.Add(node);
                 ConnectNodeToTimeline(timelinePanel, node.aEvent.EventTime);
 
@@ -706,6 +723,7 @@ namespace SeeShells.UI.Pages
         {
             try
             {
+                nodeNavigation.SetNewStartingPoint(sender);
                 if (sender.GetType() == typeof(Node.Node))
                 {
                     unToggleEventsThatAreTooClose(((Node.Node)sender).GetBlockTime());
@@ -859,6 +877,14 @@ namespace SeeShells.UI.Pages
                 // Autoscroll
                 TimelineScroll.ScrollToVerticalOffset(TimelineScroll.ExtentHeight);
             }
+        }
+
+        /// <summary>
+        /// Initializes the object used for single node navigation.
+        /// </summary>
+        private void InitializeNodeNavigation()
+        {
+            nodeNavigation = new NodeNavigation(allNodes);
         }
     }
 }

--- a/WPF/SeeShells/SeeShells/UI/Templates/NodeStyle.xaml
+++ b/WPF/SeeShells/SeeShells/UI/Templates/NodeStyle.xaml
@@ -63,6 +63,67 @@
         </Setter>
     </Style>
 
+    <Style x:Key="LitUpNode" TargetType="{x:Type ToggleButton}">
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Padding" Value="1"/>
+        <Setter Property="Height" Value="25"/>
+        <Setter Property="Width" Value="25"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Grid x:Name="grid">
+                        <Border x:Name="border" CornerRadius="8" BorderBrush="White" BorderThickness="2">
+                            <Border.Background>
+                                <RadialGradientBrush GradientOrigin="0.496,1.052">
+                                    <RadialGradientBrush.RelativeTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform CenterX="0.5" CenterY="0.5" 
+                                                        ScaleX="1.5" ScaleY="1.5"/>
+                                            <TranslateTransform X="0.02" Y="0.3"/>
+                                        </TransformGroup>
+                                    </RadialGradientBrush.RelativeTransform>
+                                    <GradientStop Offset="1" Color="#f45c43"/>
+                                    <GradientStop Offset="0.3" Color="#eb3349"/>
+                                </RadialGradientBrush>
+                            </Border.Background>
+                            <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          TextElement.FontWeight="Bold">
+                            </ContentPresenter>
+                        </Border>
+
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" TargetName="border">
+                                <Setter.Value>
+                                    <RadialGradientBrush GradientOrigin="0.496,1.052">
+                                        <RadialGradientBrush.RelativeTransform>
+                                            <TransformGroup>
+                                                <ScaleTransform CenterX="0.5" CenterY="0.5" ScaleX="1.5" ScaleY="1.5"/>
+                                                <TranslateTransform X="0.02" Y="0.3"/>
+                                            </TransformGroup>
+                                        </RadialGradientBrush.RelativeTransform>
+                                        <GradientStop Color="#f45c43" Offset="1"/>
+                                        <GradientStop Color="#eb3349" Offset="0.3"/>
+                                    </RadialGradientBrush>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="BorderBrush" TargetName="border" Value="#42858C"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" TargetName="grid" Value="0.25"/>
+                        </Trigger>
+
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="StackedNode" TargetType="{x:Type ToggleButton}">
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
@@ -107,6 +168,67 @@
                                         </RadialGradientBrush.RelativeTransform>
                                         <GradientStop Color="#5DA399" Offset="1"/>
                                         <GradientStop Color="#63CCCA" Offset="0.3"/>
+                                    </RadialGradientBrush>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="BorderBrush" TargetName="border" Value="#63CCCA"/>
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" TargetName="grid" Value="0.25"/>
+                        </Trigger>
+
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="LitUpStackedNode" TargetType="{x:Type ToggleButton}">
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Padding" Value="1"/>
+        <Setter Property="Height" Value="30"/>
+        <Setter Property="Width" Value="30"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Grid x:Name="grid">
+                        <Border x:Name="border" CornerRadius="8" BorderBrush="White" BorderThickness="2">
+                            <Border.Background>
+                                <RadialGradientBrush GradientOrigin="0.496,1.052">
+                                    <RadialGradientBrush.RelativeTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform CenterX="0.5" CenterY="0.5" 
+                                                        ScaleX="1.5" ScaleY="1.5"/>
+                                            <TranslateTransform X="0.02" Y="0.3"/>
+                                        </TransformGroup>
+                                    </RadialGradientBrush.RelativeTransform>
+                                    <GradientStop Offset="1" Color="#f45c43"/>
+                                    <GradientStop Offset="0.3" Color="#eb3349"/>
+                                </RadialGradientBrush>
+                            </Border.Background>
+                            <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          TextElement.FontWeight="Bold">
+                            </ContentPresenter>
+                        </Border>
+
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" TargetName="border">
+                                <Setter.Value>
+                                    <RadialGradientBrush GradientOrigin="0.496,1.052">
+                                        <RadialGradientBrush.RelativeTransform>
+                                            <TransformGroup>
+                                                <ScaleTransform CenterX="0.5" CenterY="0.5" ScaleX="1.5" ScaleY="1.5"/>
+                                                <TranslateTransform X="0.02" Y="0.3"/>
+                                            </TransformGroup>
+                                        </RadialGradientBrush.RelativeTransform>
+                                        <GradientStop Color="#f45c43" Offset="1"/>
+                                        <GradientStop Color="#eb3349" Offset="0.3"/>
                                     </RadialGradientBrush>
                                 </Setter.Value>
                             </Setter>


### PR DESCRIPTION
Adds two UI buttons that allow a user to navigate forwards and backwards trough the nodes, one node at a time. (I did not use the arrow keys binding, since an initial click to focus is required and also the arrows are use by the timeline scrollbar by default.)

Navigation starts from the second node when the  forwards button is pressed. (The navigation is not circular. When the end is reached, pressing the button does noting. Same applies in the opposite direction)

When a node is brought into view, it also changes color to signify that it has been navigated to.
When a user left clicks on a node, the navigation makes that node the node to start navigating from. Otherwise navigation starts from the second node or wherever it was left off.

Tested and works when the timeline is rebuilt. (Therefore it works when it's filtered as well) 

![Nav](https://user-images.githubusercontent.com/42561260/78731420-af408b80-790d-11ea-9633-a8252a4eec76.gif)

Resolves #153 