### PR TITLE
clears timeline when re-parsing

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/Home.xaml.cs
@@ -289,6 +289,10 @@ namespace SeeShells.UI.Pages
             {
                 App.ShellItems = await ParseShellBags();
                 List<IEvent> events = EventParser.GetEvents(App.ShellItems);
+                if (App.nodeCollection.nodeList != null)
+                {
+                    App.nodeCollection.nodeList.Clear();
+                }
                 App.nodeCollection.ClearAllFilters();
                 App.nodeCollection.nodeList.AddRange(NodeParser.GetNodes(events));
             }


### PR DESCRIPTION
resolves issue #319

clears the nodelist when re-parsing which eliminates adding new information to a previous parse which in turn eliminates the stacking issue that was occurring.