### PR TITLE
Fixed negative height issue

### DIFF
--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -235,6 +235,10 @@ namespace SeeShells.UI.Pages
                     node.block.Visibility = Visibility.Collapsed;
                 }
 
+                // if the last nodes were all the same time, we still need to check if they are the new highest maxStackedNodes
+                if (currentMaxStackedNodes > maxStackedNodes)
+                    maxStackedNodes = currentMaxStackedNodes;
+
                 if (nodeList.Count == 0)
                 {
                     EmptyTimeline.Visibility = Visibility.Visible;

--- a/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Pages/TimelinePage.xaml.cs
@@ -320,25 +320,13 @@ namespace SeeShells.UI.Pages
 
                 // Adds invisible blocks as padding for a nice vertical allignment.
                 int numBlocksNeeded = maxStackedNodes - stackedNode.nodes.Count;
-                TextBlock alignmentBlock;
-                if (numBlocksNeeded >= 0)
-                {
-                    alignmentBlock = new TextBlock
+                TextBlock alignmentBlock = new TextBlock
                     {
                         Style = (Style)Resources["TimelineBlock"],
                         Visibility = Visibility.Collapsed,
                         Height = numBlocksNeeded * 70
                     };
-                }
-                else
-                {
-                    alignmentBlock = new TextBlock
-                    {
-                        Style = (Style)Resources["TimelineBlock"],
-                        Visibility = Visibility.Collapsed,
-                        Height = 0
-                    };
-                }
+
                 stackedNode.alignmentBlock = alignmentBlock;
                 TimelinePanel.SetDate(stackedNode.alignmentBlock, stackedNode.nodes[0].GetBlockTime());
                 blockPanel.Children.Add(stackedNode.alignmentBlock);
@@ -366,25 +354,12 @@ namespace SeeShells.UI.Pages
                 ConnectNodeToTimeline(timelinePanel, node.aEvent.EventTime);
 
                 // Adds invisible block as padding for a nice vertical allignment.
-                TextBlock alignmentBlock;
-                if (maxStackedNodes >= 1)
-                {
-                    alignmentBlock = new TextBlock
+                TextBlock alignmentBlock = new TextBlock
                     {
                         Style = (Style)Resources["TimelineBlock"],
                         Visibility = Visibility.Collapsed,
                         Height = (maxStackedNodes - 1) * 70
                     };
-                }
-                else
-                {
-                    alignmentBlock = new TextBlock
-                    {
-                        Style = (Style)Resources["TimelineBlock"],
-                        Visibility = Visibility.Collapsed,
-                        Height = 0
-                    };
-                }
 
                 node.alignmentBlock = alignmentBlock;
                 TimelinePanel.SetDate(node.alignmentBlock, node.GetBlockTime());


### PR DESCRIPTION
Resolves #293 

When calculating the max nodes, we would count up with a local variable when the event time was the same as a previous node and do a comparison to replace maxStackedNodes when the event time was different from the previous node. I realized we would never make the comparison for any last group of nodes, thus possibly miscalculating the maxStackedNodes. It seemed likely that the case study VM would have this (probably) rare situation where there was a bunch of nodes at the end since it's not a normally used machine with a bunch of normal shellbag events.

Adding this final comparison check between maxStackedNodes and currentMaxStackedNodes seems to have fixed the issue. @klaki892 tested it on the Corporate Fraud case study VM. The program was run 5 times, resetting the VM each time. On the 5th time, he ran it against the commit where the previous program crashed (it crashed) and then ran this version of the program right after, and it worked.