### PR TITLE
Online parsing resolves actual user name before showing SID.

### DIFF
--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
@@ -62,10 +62,8 @@ namespace SeeShells.ShellParser.Registry
         {
             string retval = string.Empty;
 
-            //todo refactor this List into key-value pairs for lookup, we have to hardcode key-values otherwise.
             List<string> usernameLocations = Parser.GetUsernameLocations();
 
-            //todo we know of the Desktop value inside the "Shell Folders" location, so naively try this until a better way is found
             Dictionary<string, int> likelyUsernames = new Dictionary<string, int>();
             foreach (string usernameLocation in usernameLocations)
             {

--- a/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/Registry/OnlineRegistryReader.cs
@@ -38,11 +38,17 @@ namespace SeeShells.ShellParser.Registry
             foreach (RegistryKey userStore in userStores)
             {
                 logger.Debug("NEW USER SID: " + userStore.Name);
+                string userOfStore = FindOnlineUsername(userStore);
 
                 foreach (string location in Parser.GetRegistryLocations())
                 {
                     foreach (RegistryKeyWrapper keyWrapper in IterateRegistry(userStore.OpenSubKey(location), location, null))
                     {
+                        if (userOfStore != string.Empty)
+                        {
+                            keyWrapper.RegistryUser = userOfStore;
+                        }
+
                         retList.Add(keyWrapper);
                     }
                 }
@@ -50,6 +56,52 @@ namespace SeeShells.ShellParser.Registry
 
             return retList;
 
+        }
+
+        private string FindOnlineUsername(RegistryKey userStore)
+        {
+            string retval = string.Empty;
+
+            //todo refactor this List into key-value pairs for lookup, we have to hardcode key-values otherwise.
+            List<string> usernameLocations = Parser.GetUsernameLocations();
+
+            //todo we know of the Desktop value inside the "Shell Folders" location, so naively try this until a better way is found
+            Dictionary<string, int> likelyUsernames = new Dictionary<string, int>();
+            foreach (string usernameLocation in usernameLocations)
+            {
+                if (userStore.OpenSubKey(usernameLocation) != null)
+                {
+                    //based on the values in '...\Explorer\Shell Folders' the [2] value in the string may not always be the username, but it does appear the most.
+                    foreach (string value in userStore.OpenSubKey(usernameLocation).GetValueNames())
+                    {
+                        string valueData = (string)userStore.OpenSubKey(usernameLocation).GetValue(value);
+                        string[] pathParts = valueData.Split('\\');
+                        if (pathParts.Length > 2)
+                        {
+                            string username = pathParts[2]; //usually in the form of C:\Users\username
+                            if (!likelyUsernames.ContainsKey(username))
+                            {
+                                likelyUsernames[username] = 1;
+                            }
+                            else
+                            {
+                                likelyUsernames[username]++;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    return retval;
+                }
+            }
+            //most occurred value is probably the username.
+            if (likelyUsernames.Count >= 1)
+            {
+                retval = likelyUsernames.OrderByDescending(pair => pair.Value).First().Key;
+            }
+
+            return retval;
         }
 
         /// <summary>


### PR DESCRIPTION
The `OnlineRegistryReader` tries to resolve the actual usernames of users first and uses SIDs if resolving failed.

![image](https://user-images.githubusercontent.com/42561260/79020991-645e8800-7b48-11ea-9532-3afba336cc76.png)

Resolves #192 