### PR TITLE
Fix IO Error handling for hives and CSV files and various related bugs

### DIFF
--- a/WPF/SeeShells/SeeShells/IO/CsvParsedShellItem.cs
+++ b/WPF/SeeShells/SeeShells/IO/CsvParsedShellItem.cs
@@ -1,11 +1,14 @@
 ﻿using SeeShells.ShellParser.ShellItems;
 using System;
 using System.Collections.Generic;
+using NLog;
 
 namespace SeeShells.IO
 {
     public class CsvParsedShellItem : IShellItem
     {
+        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
         public virtual ushort Size { get => Convert.ToUInt16(allProperties[Constants.SIZE], 16); }
         public virtual byte Type { get => Convert.ToByte(allProperties[Constants.TYPE], 16); }
         public virtual string TypeName { get => allProperties[Constants.TYPENAME]; }
@@ -19,6 +22,25 @@ namespace SeeShells.IO
         public CsvParsedShellItem(IDictionary<string, string> allProperties)
         {
             this.allProperties = allProperties;
+            
+            //check to make sure all the required minimum fields exist within the CSV file
+            //required because of C# properties lazy evaluation may see the issue only during first use.
+            string[] constants = {
+                Constants.SIZE, Constants.TYPE, Constants.TYPENAME, Constants.NAME, Constants.MODIFIED_DATE,
+                Constants.ACCESSED_DATE, Constants.CREATION_DATE
+            };
+            foreach (string constant in constants)
+            {
+                try
+                {
+                    string unused = allProperties[constant];
+                }
+                catch (KeyNotFoundException ex)
+                {
+                    logger.Error(ex, $"Invalid Shellbag CSV Record. Missing required column {constant}");
+                    throw; //unusable shellItem, dont create the object.
+                }
+            }
         }
 
         public virtual IDictionary<string, string> GetAllProperties()

--- a/WPF/SeeShells/SeeShells/SeeShells.csproj
+++ b/WPF/SeeShells/SeeShells/SeeShells.csproj
@@ -189,6 +189,7 @@
     <Compile Include="ShellParser\ShellItems\ShellItem0x00.cs" />
     <Compile Include="ShellParser\ShellItems\SHITEM_UNKNOWNENTRY2.cs" />
     <Compile Include="UI\EventFilters\EventUserFilter.cs" />
+    <Compile Include="UI\LogAggregator.cs" />
     <Compile Include="UI\Node\InfoBlock.cs" />
     <Compile Include="UI\Node\NodeNavigation.cs" />
     <Compile Include="UI\Node\StackedNodes.cs" />

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellItems/IShellItem.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellItems/IShellItem.cs
@@ -12,7 +12,7 @@ namespace SeeShells.ShellParser.ShellItems
         /// </summary>
         ushort Size { get; }
         /// <summary>
-        /// Unique two byte identifier that represents an indicator for the shell item.
+        /// Unique byte identifier that represents an indicator for the shell item.
         /// Subtypes exist and must be further seperated by other information in the object. 
         /// Has no effect on signature based Shell items.
         /// See <seealso cref="TypeName"/> for a Human readable interpretation of the Shell Item.

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItem.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItem.cs
@@ -10,7 +10,19 @@ namespace SeeShells.ShellParser.ShellItems
     {
         public virtual ushort Size { get; protected set; }
         public virtual byte Type { get; protected set; }
-        public virtual string TypeName { get; protected set; }
+
+        public virtual string TypeName
+        {
+            get
+            {
+                return "Unknown";
+            }
+            protected set
+            {
+
+            }
+        }
+
         public virtual string Name
         {
             get

--- a/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItem0x00.cs
+++ b/WPF/SeeShells/SeeShells/ShellParser/ShellItems/ShellItem0x00.cs
@@ -5,7 +5,6 @@ namespace SeeShells.ShellParser.ShellItems
     public class ShellItem0x00 : ShellItem
     {
         public string Guid { get; protected set; }
-        public override string TypeName { get => "Unknown"; }
         public override string Name
         {
             get

--- a/WPF/SeeShells/SeeShells/UI/LogAggregator.cs
+++ b/WPF/SeeShells/SeeShells/UI/LogAggregator.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace SeeShells.UI
+{
+
+    /**
+     *Aggregates multiple messages (logs) together for later retrieval of a compilation
+     */
+    public class LogAggregator
+    {
+        private List<string> logs;
+        private LogAggregator()
+        {
+            logs = new List<string>();
+        }
+
+        public static LogAggregator Instance { get; } = new LogAggregator();
+
+        public void Add(string message)
+        {
+            logs.Add(message);
+        }
+
+        /**
+         * Clears all the logs in the aggregator
+         * Very dangerous because LogAggregator is a Singleton.
+         * High chance of deleting unknown logs.
+         */
+        public void Clear()
+        {
+            logs.Clear();
+        }
+
+        protected string CompileMessage()
+        {
+
+            StringBuilder displayMessage = new StringBuilder();
+            logs.ForEach(log => displayMessage.AppendLine(log));
+
+            return displayMessage.ToString();
+        }
+
+        /**
+         * Shows all added log messages in a <seealso cref="MessageBox"/>
+         * Will not display the messagebox if no logs have been recorded
+         * Clears the accumulated logs afterwards.
+         */
+        public void ShowIfNotEmpty()
+        {
+            if (logs.Count == 0)
+            {
+                return;
+            }
+
+            MessageBox.Show(CompileMessage(), "SeeShells", MessageBoxButton.OK, MessageBoxImage.Information);
+            Clear();
+        }
+    }
+}

--- a/WPF/SeeShells/SeeShells/UI/Templates/Switch.xaml.cs
+++ b/WPF/SeeShells/SeeShells/UI/Templates/Switch.xaml.cs
@@ -18,6 +18,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using SeeShells.ShellParser.ShellItems;
 
 namespace SeeShells.UI.Templates
 {
@@ -77,12 +78,20 @@ namespace SeeShells.UI.Templates
             OpenFileDialog openFileDialog = new OpenFileDialog
             {
                 InitialDirectory = Directory.GetCurrentDirectory(),
-                Filter = "CSV File (*.csv)|*.csv"
+                Filter = "CSV File (*.csv)|*.csv",
+                ReadOnlyChecked = true
             };
 
             if (openFileDialog.ShowDialog() != true)
                 return;
             var file = openFileDialog.FileName;
+            List<IShellItem> csvShelltems = CsvIO.ImportCSVFile(file);
+            if (csvShelltems.Count == 0)
+            {
+                LogAggregator.Instance.ShowIfNotEmpty();
+                return;
+            }
+
             if (App.ShellItems != null)
             {
                 App.ShellItems.Clear();
@@ -92,7 +101,7 @@ namespace SeeShells.UI.Templates
                 App.nodeCollection.nodeList.Clear();
             }
 
-            App.ShellItems = CsvIO.ImportCSVFile(file);
+            App.ShellItems = csvShelltems;
             List<IEvent> events = EventParser.GetEvents(App.ShellItems);
             App.nodeCollection.ClearAllFilters();
             App.nodeCollection.nodeList.AddRange(NodeParser.GetNodes(events));
@@ -115,7 +124,7 @@ namespace SeeShells.UI.Templates
                     App.NavigationService.Navigate(Home.timelinePage);
                 }
             }
-
+            LogAggregator.Instance.ShowIfNotEmpty();
         }
     }
 }


### PR DESCRIPTION
- Adds Log message aggregator to display message boxes of information about a parsing operation
- Adds Error handling to support invalid files being passed to CSV parser and Offline Hive parser
- Fixes CSV file appending all changes to existing files, causing subsequent reading errors due to multiple header rows
- Fixes CSV import failing to a read a file if another program has the same file open
- Added check for required Event fields on CSV Import, shows error message detailing if missing basic required information
- Adds error messages for individual line items in a CSV Import operation
- fixes case where offline and online usernames not being found would cause program to crash
- Fixes Shellbag0x01 and all unknown shellbags not having a TypeName field, a required piece of information for event handling
- Adds Messages detailing when no events/shellbags could be found from a parsing operation

Video Showcases the new messagebox with messages for:
- invalid files
- line items being wrong in CSV
- Shows still working offline parser and CSV Import
![97aadb37-f1f4-43f7-8cdf-18d5b9d300b1](https://user-images.githubusercontent.com/17878901/79104969-adc3f880-7d3d-11ea-860c-11339f8b6e00.gif)
![9f27e8d2-a193-46e7-bf66-d59a1ba34edd](https://user-images.githubusercontent.com/17878901/79105263-53776780-7d3e-11ea-8059-0ca255ae2420.gif)
